### PR TITLE
🐛 스토리북 절대 경로 설정

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -1,4 +1,5 @@
 import type { StorybookConfig } from '@storybook/nextjs'
+import TsconfigPathsPlugin from 'tsconfig-paths-webpack-plugin'
 
 const config: StorybookConfig = {
   stories: ['../src/**/*.mdx', '../src/**/*.stories.@(js|jsx|mjs|ts|tsx)'],
@@ -14,6 +15,12 @@ const config: StorybookConfig = {
   },
   docs: {
     autodocs: 'tag',
+  },
+
+  webpackFinal: async (config) => {
+    if (config && config.resolve)
+      config.resolve.plugins = [new TsconfigPathsPlugin()]
+    return config
   },
 }
 export default config


### PR DESCRIPTION
## - 목적
관련 이슈: https://github.com/prgrms-fe-devcourse/FEDC4_Price-PCC_DONGYOUNG/issues/7
- 스토리북에서 절대경로 @사용하게 설정

<br>

## - 주요 변경 사항

- storybook폴더의 main.ts에 스토리북 절대경로 @ 사용하게 처리했어요

## 기타 사항 (선택)

- https://stackoverflow.com/questions/66444895/how-to-resolve-aliases-in-storybook

<br>

## - 스크린샷 (선택)
설정을 안해주었을 경우
![image](https://github.com/prgrms-fe-devcourse/FEDC4_Price-PCC_DONGYOUNG/assets/59411107/ead9b0a8-a832-4d25-a3a4-d8451fdcf749)

설정을 해주었을 경우
![image](https://github.com/prgrms-fe-devcourse/FEDC4_Price-PCC_DONGYOUNG/assets/59411107/5e42b7cc-8a5c-40fd-871f-7e7451270389)

