### PR TITLE
:tada: 이미지 업로드 로직 수정

### DIFF
--- a/src/app/api/posts/create/route.ts
+++ b/src/app/api/posts/create/route.ts
@@ -5,22 +5,20 @@ import { Environment } from '@/config/environments'
 import { apiClient } from '@/lib/axios'
 
 export async function POST(request: Request) {
-  const { title, image } = await request.json()
+  const formData = await request.formData()
   const channelId = Environment.channelId()
+  formData.append('channelId', channelId)
 
   const cookieStore = cookies()
   const token = JSON.parse(cookieStore.get(constants.AUTH_TOKEN)?.value!)
 
   const { data } = await apiClient.post(
     `${Environment.baseUrl()}/posts/create`,
-    {
-      title: JSON.stringify(title),
-      image,
-      channelId,
-    },
+    formData,
     {
       headers: {
         Authorization: 'Bearer ' + token,
+        'Content-Type': 'multipart/form-data',
       },
     },
   )

--- a/src/components/molcules/file-picker/index.tsx
+++ b/src/components/molcules/file-picker/index.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import React, {
   useState,
   useRef,
@@ -9,7 +7,6 @@ import React, {
 } from 'react'
 import Image from 'next/image'
 import Assets from '@/config/assets'
-import { fileToBaseUrl } from '@/utils/FiletoBaseUrl'
 import './index.scss'
 import useDragging from './useDragging'
 
@@ -19,7 +16,7 @@ type FilePickerProps = {
   disabled?: boolean
   width?: number
   height?: number
-  onChange?: (_files: string) => void
+  onChange?: (_files: FileList) => void
   className?: string
 }
 
@@ -27,12 +24,13 @@ export default function FilePicker({
   name,
   multiple = false,
   disabled,
-  width = 24.5,
-  height = 17,
+  width = 5,
+  height = 5,
   onChange,
   className,
 }: FilePickerProps) {
   useEffect(() => {})
+  const [_files, setFiles] = useState<FileList | null>(null)
   const [thumbNail, setThumbNail] = useState<string>('')
   const dropDownRef = useRef<HTMLDivElement | null>(null)
   const fileUploadRef = useRef<HTMLInputElement | null>(null)
@@ -46,10 +44,11 @@ export default function FilePicker({
   }, [])
 
   const { targetRef } = useDragging(dropDownRef, (_newFiles) => {
+    setFiles(_newFiles)
     const newThumbNailImage = createNewThumbNailImage(_newFiles)
     setThumbNail(newThumbNailImage)
     if (onChange) {
-      fileToBaseUrl(_newFiles[0]).then((value) => onChange(value))
+      onChange(_newFiles)
     }
   })
 
@@ -57,14 +56,15 @@ export default function FilePicker({
 
   const handleFileChange = (e: ChangeEvent<HTMLInputElement>) => {
     if (e.target.files) {
-      const blob = new Blob([e.target.files[0]], {
-        type: e.target.files[0].type,
-      })
-
-      const thumbNailImage = URL.createObjectURL(blob)
-      setThumbNail(thumbNailImage)
+      setFiles(e.target.files)
       if (onChange) {
-        fileToBaseUrl(e.target.files[0]).then((value) => onChange(value))
+        onChange(e.target.files)
+        const blob = new Blob([e.target.files[0]], {
+          type: e.target.files[0].type,
+        })
+
+        const thumbNailImage = URL.createObjectURL(blob)
+        setThumbNail(thumbNailImage)
       }
     }
   }

--- a/src/components/templates/NewPostPageTemplate/NewPostPageTemplate.tsx
+++ b/src/components/templates/NewPostPageTemplate/NewPostPageTemplate.tsx
@@ -39,7 +39,7 @@ export default function NewPostPageTemplate() {
           width={20}
           height={10}
           onChange={(file) => {
-            setValue('image', file)
+            setValue('image', file[0])
           }}
         />
       </div>

--- a/src/hooks/useUploadForm.ts
+++ b/src/hooks/useUploadForm.ts
@@ -1,12 +1,12 @@
 import { useForm } from 'react-hook-form'
 import { useRouter } from 'next/navigation'
 import APP_PATH from '@/config/paths'
-import { apiClient } from '@/lib/axios'
+import { postUserPost } from '@/services/post'
 
 interface UploadFormData {
   title: string
   description: string
-  image: string | BinaryData | null
+  image: File
 }
 
 export const useUploadForm = () => {
@@ -16,14 +16,14 @@ export const useUploadForm = () => {
 
   const onSubmit = async ({ title, description, image }: UploadFormData) => {
     try {
-      const res = await apiClient.post('/api/posts/create', {
+      const res = await postUserPost({
         title: {
           title,
           description,
         },
         image,
       })
-      // TODO: 이미지 base64로 변환해서 전송
+
       if (res.status === 200) {
         alert('업로드 성공')
         router.push(APP_PATH.home())

--- a/src/lib/axios.ts
+++ b/src/lib/axios.ts
@@ -1,17 +1,8 @@
 import axios from 'axios'
 import { redirect } from 'next/navigation'
-import { Environment } from '@/config/environments'
 import APP_PATH from '@/config/paths'
-import { ApiAddressTypes } from '@/types/config'
-
-const baseUrlTable: ApiAddressTypes = {
-  production: 'http://localhost:3000',
-  development: 'http://localhost:3000',
-  test: 'http://localhost:3000',
-}
 
 export const apiClient = axios.create({
-  baseURL: baseUrlTable[Environment.nodeEnv()],
   headers: {
     'Content-Type': 'application/json',
   },
@@ -22,8 +13,12 @@ apiClient.interceptors.response.use(
     return response
   },
   (error) => {
+    console.log(error)
     if (error.response.status === 401) {
       redirect(APP_PATH.home())
+    }
+    if (error.response.status === 413) {
+      alert('이미지 용량이 너무 큽니다.')
     }
     return Promise.reject(error)
   },

--- a/src/services/post/index.ts
+++ b/src/services/post/index.ts
@@ -5,11 +5,18 @@ interface PostUserBody {
     title: string
     description: string
   }
-  image?: BinaryData | null
+  image?: File
 }
 
 export const postUserPost = async (body: PostUserBody) => {
-  const { data } = await apiClient.post('/api/posts/create', body)
+  const formData = new FormData()
+  formData.append('title', JSON.stringify(body.title))
+  formData.append('image', body.image!)
+  const { data } = await apiClient.post('/api/posts/create', formData, {
+    headers: {
+      'Content-Type': 'multipart/form-data',
+    },
+  })
   return data
 }
 


### PR DESCRIPTION
## - 목적
관련 이슈: #76

<br>

## - 주요 변경 사항

- base64 인코딩 안하는걸로 원복했습니다.
- 이미지 정상 업로드 확인, form 데이터를 주고받도록 설정

## 기타 사항 (선택)

- formData나 Image 처리를 제대로 안 해봐서 삽질했네요... 이번 기회에 배워갑니다. 그리고 효중님께 심심한 사과말씀...
- Post의 예시를 첨부하오니 참고해주세요.
```json
{
            "likes": [],
            "comments": [],
            "_id": "650308a4b888c17b6e4cafb3",
            "title": "{\"title\":\"ㄹㅇㅋㅋㅋ\",\"description\":\"<p>ㅇㄹ</p>\"}",
            "image": "https://res.cloudinary.com/learnprogrammers/image/upload/v1694697635/post/f1e33b68-55ce-431e-9df3-d4c593fcec53.jpg",
            "imagePublicId": "post/f1e33b68-55ce-431e-9df3-d4c593fcec53",
            "channel": "6502b140b25bef7561632608",
            "author": "64fab77574d7b20fbc7ac3a4",
            "createdAt": "2023-09-14T13:20:36.009Z",
            "updatedAt": "2023-09-14T13:20:36.009Z",
            "__v": 0
        },
```

<br>

## - 스크린샷 (선택)
