### PR TITLE
🎉 메인 페이지 무한 스크롤 (훅 분리 완료)

### DIFF
--- a/src/app/(root)/(routes)/(home)/page.tsx
+++ b/src/app/(root)/(routes)/(home)/page.tsx
@@ -4,10 +4,8 @@ import CardGridTemplate from '@/components/templates/CardGridTemplate'
 import { useInfiniteScroll } from '@/hooks/useInfiniteScroll'
 import useGetAllPosts from '@/queries/channel'
 
-const CHANNEL_ID = process.env.NEXT_PUBLIC_CHANNEL_ID as string
-
 export default function Home() {
-  const { data, fetchNextPage, hasNextPage } = useGetAllPosts(CHANNEL_ID)
+  const { data, fetchNextPage, hasNextPage } = useGetAllPosts()
 
   const { observerElem } = useInfiniteScroll({ fetchNextPage, hasNextPage })
 

--- a/src/app/(root)/(routes)/(home)/page.tsx
+++ b/src/app/(root)/(routes)/(home)/page.tsx
@@ -1,7 +1,7 @@
 'use client'
 
-import { useEffect, useRef } from 'react'
 import CardGridTemplate from '@/components/templates/CardGridTemplate'
+import { useInfiniteScroll } from '@/hooks/useInfiniteScroll'
 import useGetAllPosts from '@/queries/channel'
 
 const CHANNEL_ID = process.env.NEXT_PUBLIC_CHANNEL_ID as string
@@ -9,24 +9,7 @@ const CHANNEL_ID = process.env.NEXT_PUBLIC_CHANNEL_ID as string
 export default function Home() {
   const { data, fetchNextPage, hasNextPage } = useGetAllPosts(CHANNEL_ID)
 
-  const observerElem = useRef(null)
-
-  useEffect(() => {
-    const element = observerElem.current
-    const option = { threshold: 0.5 }
-
-    const io = new IntersectionObserver((entries) => {
-      const [target] = entries
-      if (target.isIntersecting) {
-        fetchNextPage()
-      }
-    }, option)
-
-    if (hasNextPage && element) {
-      io.observe(element)
-      return () => io.unobserve(element)
-    }
-  }, [fetchNextPage, hasNextPage])
+  const { observerElem } = useInfiniteScroll({ fetchNextPage, hasNextPage })
 
   return <CardGridTemplate postDatas={data?.pages.flat()} ref={observerElem} />
 }

--- a/src/app/(root)/(routes)/(home)/page.tsx
+++ b/src/app/(root)/(routes)/(home)/page.tsx
@@ -1,11 +1,32 @@
 'use client'
 
+import { useEffect, useRef } from 'react'
 import CardGridTemplate from '@/components/templates/CardGridTemplate'
 import useGetAllPosts from '@/queries/channel'
 
 const CHANNEL_ID = process.env.NEXT_PUBLIC_CHANNEL_ID as string
 
 export default function Home() {
-  const { data } = useGetAllPosts(CHANNEL_ID)
-  return <CardGridTemplate postDatas={data?.posts} />
+  const { data, fetchNextPage, hasNextPage } = useGetAllPosts(CHANNEL_ID)
+
+  const observerElem = useRef(null)
+
+  useEffect(() => {
+    const element = observerElem.current
+    const option = { threshold: 0.5 }
+
+    const io = new IntersectionObserver((entries) => {
+      const [target] = entries
+      if (target.isIntersecting) {
+        fetchNextPage()
+      }
+    }, option)
+
+    if (hasNextPage && element) {
+      io.observe(element)
+      return () => io.unobserve(element)
+    }
+  }, [fetchNextPage, hasNextPage])
+
+  return <CardGridTemplate postDatas={data?.pages.flat()} ref={observerElem} />
 }

--- a/src/app/api/channel/[channelId]/route.ts
+++ b/src/app/api/channel/[channelId]/route.ts
@@ -31,11 +31,12 @@ export async function GET(req: NextRequest) {
     const posts = await getAllPosts(id, offset, limit)
 
     const parsedPosts = posts.map((post: Post) => {
-      if (JSON.parse(post.title)) {
+      const parsedArticle = JSON.parse(post.title)
+      if (parsedArticle) {
         return {
           ...post,
-          title: JSON.parse(post.title).title,
-          description: JSON.parse(post.title).description,
+          title: parsedArticle.title,
+          description: parsedArticle.description,
         }
       } else {
         return {
@@ -44,7 +45,7 @@ export async function GET(req: NextRequest) {
         }
       }
     })
-    return new Response(JSON.stringify({ posts: parsedPosts }), { status: 200 })
+    return new Response(JSON.stringify(parsedPosts), { status: 200 })
   } catch (error) {
     if (error instanceof Error)
       return new Response(JSON.stringify({ error: error.message }), {

--- a/src/app/api/channel/[channelId]/route.ts
+++ b/src/app/api/channel/[channelId]/route.ts
@@ -1,10 +1,10 @@
 import { NextRequest } from 'next/server'
 import Post from '@/types/post'
 
-async function getAllPosts(id: string) {
+async function getAllPosts(id: string, offset: string, limit: string) {
   try {
     const response = await fetch(
-      `${process.env.NEXT_PUBLIC_API_ADDRESS}/posts/channel/${id}`,
+      `${process.env.NEXT_PUBLIC_API_ADDRESS}/posts/channel/${id}?offset=${offset}&limit=${limit}`,
       {
         cache: 'no-cache',
       },
@@ -23,9 +23,12 @@ async function getAllPosts(id: string) {
 }
 
 export async function GET(req: NextRequest) {
-  const id = req.nextUrl.pathname.replace('/api/channel/', '')
+  const { searchParams, pathname } = req.nextUrl
+  const id = pathname.replace('/api/channel/', '')
+  const offset = searchParams.get('offset') as string
+  const limit = searchParams.get('limit') as string
   try {
-    const posts = await getAllPosts(id)
+    const posts = await getAllPosts(id, offset, limit)
 
     const parsedPosts = posts.map((post: Post) => {
       if (JSON.parse(post.title)) {

--- a/src/app/api/posts/route.ts
+++ b/src/app/api/posts/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest } from 'next/server'
+import { Environment } from '@/config/environments'
 import Post from '@/types/post'
 
 async function getAllPosts(id: string, offset: string, limit: string) {
@@ -23,8 +24,8 @@ async function getAllPosts(id: string, offset: string, limit: string) {
 }
 
 export async function GET(req: NextRequest) {
-  const { searchParams, pathname } = req.nextUrl
-  const id = pathname.replace('/api/channel/', '')
+  const id = Environment.channelId()
+  const { searchParams } = req.nextUrl
   const offset = searchParams.get('offset') as string
   const limit = searchParams.get('limit') as string
   try {

--- a/src/components/templates/CardGridTemplate/CardGridTemplate.tsx
+++ b/src/components/templates/CardGridTemplate/CardGridTemplate.tsx
@@ -1,12 +1,18 @@
+'use client'
+
+import { forwardRef, ForwardedRef } from 'react'
 import { CardPostItem } from '@/components/organisms/CardPostItem'
 import { CardPostItemProps } from '@/components/organisms/CardPostItem/CardPostItem'
 import Post from '@/types/post'
 import './index.scss'
 
 type CardGridTemplateProps = {
-  postDatas: Post[]
+  postDatas: Post[] | undefined
 }
-export default function CardGridTemplate({ postDatas }: CardGridTemplateProps) {
+export default forwardRef(function CardGridTemplate(
+  { postDatas }: CardGridTemplateProps,
+  ref: ForwardedRef<null>,
+) {
   return (
     <div className="card-grid-container">
       {postDatas?.map(
@@ -21,6 +27,7 @@ export default function CardGridTemplate({ postDatas }: CardGridTemplateProps) {
           />
         ),
       )}
+      <div id="observeTarget" ref={ref} />
     </div>
   )
-}
+})

--- a/src/components/templates/CardGridTemplate/index.scss
+++ b/src/components/templates/CardGridTemplate/index.scss
@@ -1,6 +1,7 @@
 @import '@/styles/variables';
 
 .card-grid-container {
+  width: 100%;
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(22rem, 1fr));
   grid-auto-rows: minmax(20.5rem, 1fr);

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -1,5 +1,6 @@
 const constants = {
   AUTH_TOKEN: 'auth-token',
+  INFINITE_LIMIT: 10,
 } as const
 
 export { constants }

--- a/src/hooks/useInfiniteScroll.ts
+++ b/src/hooks/useInfiniteScroll.ts
@@ -1,0 +1,34 @@
+import { useRef, useEffect } from 'react'
+import { InfiniteQueryObserverResult } from '@tanstack/react-query'
+import Post from '@/types/post'
+
+type UseInfiniteScroll = {
+  fetchNextPage: () => Promise<InfiniteQueryObserverResult<Post[], unknown>>
+  hasNextPage: boolean | undefined
+}
+
+export const useInfiniteScroll = ({
+  fetchNextPage,
+  hasNextPage,
+}: UseInfiniteScroll) => {
+  const observerElem = useRef(null)
+
+  useEffect(() => {
+    const element = observerElem.current
+    const option = { threshold: 0.5 }
+
+    const io = new IntersectionObserver((entries) => {
+      const [target] = entries
+      if (target.isIntersecting) {
+        fetchNextPage()
+      }
+    }, option)
+
+    if (hasNextPage && element) {
+      io.observe(element)
+      return () => io.unobserve(element)
+    }
+  }, [fetchNextPage, hasNextPage])
+
+  return { observerElem }
+}

--- a/src/queries/channel/index.ts
+++ b/src/queries/channel/index.ts
@@ -1,13 +1,13 @@
-import { useQuery } from '@tanstack/react-query'
+import { useInfiniteQuery } from '@tanstack/react-query'
 import { getAllPosts } from '@/services/channel'
 
 const useGetAllPosts = (channelId: string) => {
-  return useQuery({
-    queryKey: ['getAllPosts', channelId],
-    queryFn: async () => {
-      const data = await getAllPosts(channelId)
-      return data
-    },
+  const LIMIT = 5
+
+  return useInfiniteQuery({
+    queryKey: ['getAllPostsInfiniteQuery'],
+    queryFn: ({ pageParam = 0 }) =>
+      getAllPosts({ channelId, offset: pageParam, limit: LIMIT }),
   })
 }
 

--- a/src/queries/channel/index.ts
+++ b/src/queries/channel/index.ts
@@ -2,12 +2,11 @@ import { useInfiniteQuery } from '@tanstack/react-query'
 import { constants } from '@/config/constants'
 import { getAllPosts } from '@/services/channel'
 
-const useGetAllPosts = (channelId: string) => {
+const useGetAllPosts = () => {
   return useInfiniteQuery({
     queryKey: ['getAllPostsInfiniteQuery'],
     queryFn: ({ pageParam = 0 }) =>
       getAllPosts({
-        channelId,
         offset: pageParam,
         limit: constants.INFINITE_LIMIT,
       }),

--- a/src/queries/channel/index.ts
+++ b/src/queries/channel/index.ts
@@ -2,12 +2,13 @@ import { useInfiniteQuery } from '@tanstack/react-query'
 import { getAllPosts } from '@/services/channel'
 
 const useGetAllPosts = (channelId: string) => {
-  const LIMIT = 5
+  const LIMIT = 10
 
   return useInfiniteQuery({
     queryKey: ['getAllPostsInfiniteQuery'],
     queryFn: ({ pageParam = 0 }) =>
       getAllPosts({ channelId, offset: pageParam, limit: LIMIT }),
+    getNextPageParam: (lastPage, allPages) => allPages.flat().length,
   })
 }
 

--- a/src/queries/channel/index.ts
+++ b/src/queries/channel/index.ts
@@ -1,13 +1,16 @@
 import { useInfiniteQuery } from '@tanstack/react-query'
+import { constants } from '@/config/constants'
 import { getAllPosts } from '@/services/channel'
 
 const useGetAllPosts = (channelId: string) => {
-  const LIMIT = 10
-
   return useInfiniteQuery({
     queryKey: ['getAllPostsInfiniteQuery'],
     queryFn: ({ pageParam = 0 }) =>
-      getAllPosts({ channelId, offset: pageParam, limit: LIMIT }),
+      getAllPosts({
+        channelId,
+        offset: pageParam,
+        limit: constants.INFINITE_LIMIT,
+      }),
     getNextPageParam: (lastPage, allPages) => allPages.flat().length,
   })
 }

--- a/src/services/channel/index.ts
+++ b/src/services/channel/index.ts
@@ -2,19 +2,17 @@ import { apiClient } from '@/lib/axios'
 import Post from '@/types/post'
 
 type GetAllPosts = {
-  channelId: string
   offset: number
   limit: number
 }
 
 export const getAllPosts = async ({
-  channelId,
   offset,
   limit,
 }: GetAllPosts): Promise<Post[]> => {
   try {
     const { data } = await apiClient.get(
-      `api/channel/${channelId}?offset=${offset}&limit=${limit}`,
+      `api/posts?offset=${offset}&limit=${limit}`,
     )
     return data
   } catch (e) {

--- a/src/services/channel/index.ts
+++ b/src/services/channel/index.ts
@@ -1,15 +1,17 @@
 import { apiClient } from '@/lib/axios'
+import Post from '@/types/post'
 
 type GetAllPosts = {
   channelId: string
   offset: number
   limit: number
 }
+
 export const getAllPosts = async ({
   channelId,
   offset,
   limit,
-}: GetAllPosts) => {
+}: GetAllPosts): Promise<Post[]> => {
   try {
     const { data } = await apiClient.get(
       `api/channel/${channelId}?offset=${offset}&limit=${limit}`,
@@ -17,5 +19,6 @@ export const getAllPosts = async ({
     return data
   } catch (e) {
     if (e instanceof Error) throw new Error(e.message)
+    return []
   }
 }

--- a/src/services/channel/index.ts
+++ b/src/services/channel/index.ts
@@ -1,7 +1,7 @@
 import { apiClient } from '@/lib/axios'
 import Post from '@/types/post'
 
-type GetAllPosts = {
+type GetAllPostsReq = {
   offset: number
   limit: number
 }
@@ -9,7 +9,7 @@ type GetAllPosts = {
 export const getAllPosts = async ({
   offset,
   limit,
-}: GetAllPosts): Promise<Post[]> => {
+}: GetAllPostsReq): Promise<Post[]> => {
   try {
     const { data } = await apiClient.get(
       `api/posts?offset=${offset}&limit=${limit}`,

--- a/src/services/channel/index.ts
+++ b/src/services/channel/index.ts
@@ -1,8 +1,19 @@
 import { apiClient } from '@/lib/axios'
 
-export const getAllPosts = async (channelId: string) => {
+type GetAllPosts = {
+  channelId: string
+  offset: number
+  limit: number
+}
+export const getAllPosts = async ({
+  channelId,
+  offset,
+  limit,
+}: GetAllPosts) => {
   try {
-    const { data } = await apiClient.get(`api/channel/${channelId}`)
+    const { data } = await apiClient.get(
+      `api/channel/${channelId}?offset=${offset}&limit=${limit}`,
+    )
     return data
   } catch (e) {
     if (e instanceof Error) throw new Error(e.message)


### PR DESCRIPTION
## - 목적
관련 이슈: #15 
-

<br>

## - 주요 변경 사항

- useInfiniteQuery + Intersection Observer 를 사용하여 무한스크롤을 구현했습니다.


## 기타 사항 (선택)

- useInfiniteScroll 훅을 만들었습니다.
- useInifiniteQuery가 반환하는 `fetchNextPage`, `hasNextPage`를 인자로 전달하면 IntersectionObserver의 관찰 대상인 ref (`observerElem`)를 반환합니다. 반환해주는 ref를 관찰 대상 Element에 ref 값으로 지정해주시면 됩니다.

<br>

## - 스크린샷 (선택)
