### PR TITLE
:tada: 메인 레이아웃 수정 완료

### DIFF
--- a/src/app/(root)/layout.tsx
+++ b/src/app/(root)/layout.tsx
@@ -25,7 +25,7 @@ export default function RootLayout({
             className={`${pretendardFont.Regular.className} pcc-theme--light`}
           >
             <NavBar />
-<div className="main-container">
+            <div className="main-container">
               <Header />
               <main>{children}</main>
             </div>

--- a/src/components/organisms/Header/index.scss
+++ b/src/components/organisms/Header/index.scss
@@ -11,14 +11,12 @@
   justify-content: flex-end;
   align-items: center;
   border-radius: 1rem 0 0 1rem;
-  width: 85vw;
+  width: calc(100% - 20rem);
   height: 5rem;
   position: fixed;
-  margin-left: 17rem;
-  padding-right: 3vw;
   z-index: 1;
+  padding: 0 3rem 0 2rem;
   top: 0%;
-  left: 0%;
 }
 
 .header-button-container {

--- a/src/components/organisms/NavBar/index.scss
+++ b/src/components/organisms/NavBar/index.scss
@@ -2,15 +2,13 @@
 
 .nav-container {
   width: 20rem;
-  height: 100vh;
+  height: 100%;
   display: flex;
   flex-direction: column;
   align-items: center;
   border-radius: 0 1rem 1rem 0;
   position: fixed;
-  z-index: 1;
   top: 0%;
-  left: 0%;
 
   .image-button {
     padding: 2rem 0;

--- a/src/styles/layout.scss
+++ b/src/styles/layout.scss
@@ -1,22 +1,15 @@
+.main-container {
+  width: calc(100% - 20rem);
+  height: auto;
+  margin-left: 20rem;
+}
+
 main {
-  margin-top: 10vh;
-  margin-left: 15vw;
-  width: 85vw;
+  margin-top: 5rem;
   height: auto;
   display: flex;
-  z-index: 0;
   justify-content: center;
   align-items: center;
   padding: 3rem;
-}
-
-.main-container {
-  display: flex;
-  flex-direction: column;
-  height: auto;
-}
-
-body {
-  display: flex;
-  overflow-x: hidden;
+  z-index: 0;
 }


### PR DESCRIPTION
## - 목적
관련 이슈: #104 

<br>

## - 주요 변경 사항
- 사이드바 width는 20rem으로 고정, height는 100%로 설정했습니다.
- 헤더같은 경우 width는 100% - 20rem으로 설정하고, height는 5rem으로 고정했습니다.
- 메인은 헤더와 같은 width에 height는 auto로 설정했으며, padding을 주었습니다.

## 기타 사항 (선택)

-

<br>

## - 스크린샷 (선택)
![ezgif com-crop](https://github.com/prgrms-fe-devcourse/FEDC4_Price-PCC_DONGYOUNG/assets/83554018/51362549-c339-44c8-a1b0-a49027e6c5f6)
