### PR TITLE
✨ 다크모드 새로고침 로컬스토리지 유지

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7668,7 +7668,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
       "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "normalize-path": "^3.0.0",
         "picomatch": "^2.0.4"
@@ -8305,7 +8305,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
       "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=8"
       }
@@ -8816,7 +8816,7 @@
       "version": "3.5.3",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
       "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "individual",
@@ -8843,7 +8843,7 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "is-glob": "^4.0.1"
       },
@@ -12268,7 +12268,7 @@
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.4.tgz",
       "integrity": "sha512-fsXeu4J4i6WNWSikpI88v/PcVflZz+6kMhUfIwc5SY+poQRPnaf5V7qds6SUyUN3cVxEzuCab7QIoLOQ+DQ1wA==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/import-fresh": {
       "version": "3.3.0",
@@ -12425,7 +12425,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
       "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "binary-extensions": "^2.0.0"
       },
@@ -14435,7 +14435,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -16070,7 +16070,7 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
       "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "picomatch": "^2.2.1"
       },
@@ -16555,7 +16555,7 @@
       "version": "1.66.1",
       "resolved": "https://registry.npmjs.org/sass/-/sass-1.66.1.tgz",
       "integrity": "sha512-50c+zTsZOJVgFfTgwwEzkjA3/QACgdNsKueWPyAR0mRINIvLAStVQBbPg14iuqEQ74NPDbXzJARJ/O4SI1zftA==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "chokidar": ">=3.0.0 <4.0.0",
         "immutable": "^4.0.0",

--- a/src/components/atoms/DarkModeButton/index.tsx
+++ b/src/components/atoms/DarkModeButton/index.tsx
@@ -22,7 +22,6 @@ export default function DarkModeButton() {
   const handleDarkmodeClick = () => {
     document.body.classList.toggle('pcc-theme--light')
     document.body.classList.toggle('pcc-theme--dark')
-    console.log('darkMode', darkMode)
     setDarkMode(!darkMode)
   }
 

--- a/src/components/atoms/DarkModeButton/index.tsx
+++ b/src/components/atoms/DarkModeButton/index.tsx
@@ -6,15 +6,10 @@ import useStorage from '@/hooks/useStorage'
 import ImageButton from '../ImageButton'
 
 export default function DarkModeButton() {
-  let isSystemDark = false
-  if (typeof window !== 'undefined') {
-    isSystemDark = window.matchMedia('(prefers-color-scheme: dark)').matches
-  }
-
   const [darkMode, setDarkMode] = useStorage<boolean>({
     storageType: 'local',
     key: 'pcc-darkmode',
-    initialValue: isSystemDark,
+    initialValue: window.matchMedia('(prefers-color-scheme: dark)').matches,
   })
 
   useEffect(() => {
@@ -27,13 +22,14 @@ export default function DarkModeButton() {
   const handleDarkmodeClick = () => {
     document.body.classList.toggle('pcc-theme--light')
     document.body.classList.toggle('pcc-theme--dark')
+    console.log('darkMode', darkMode)
     setDarkMode(!darkMode)
   }
 
   return (
     <ImageButton
       size={3}
-      src={darkMode ? Assets.DARKMODE_SVG_PATH : Assets.LIGHTMODE_SVG_PATH}
+      src={darkMode ? Assets.LIGHTMODE_SVG_PATH : Assets.DARKMODE_SVG_PATH}
       alt={`${darkMode ? 'dark' : 'light'} mode button`}
       onClick={handleDarkmodeClick}
     />

--- a/src/components/organisms/Header/Header.tsx
+++ b/src/components/organisms/Header/Header.tsx
@@ -1,9 +1,9 @@
 'use client'
 
 import { useEffect, useState } from 'react'
+import dynamic from 'next/dynamic'
 import Link from 'next/link'
 import Avatar from '@/components/atoms/Avatar'
-import DarkModeButton from '@/components/atoms/DarkModeButton'
 import ImageButton from '@/components/atoms/ImageButton'
 import NotificationButton from '@/components/atoms/NotificationButton'
 import SearchBar from '@/components/atoms/SearchBar'
@@ -13,6 +13,11 @@ import Assets from '@/config/assets'
 import APP_PATH from '@/config/paths'
 import { useCurrentUser } from '@/hooks/useCurrentUser'
 import './index.scss'
+
+const DynamicDarkModeButton = dynamic(
+  () => import('@/components/atoms/DarkModeButton'),
+  { ssr: false },
+)
 
 export default function Header() {
   const isCookie = useCurrentUser().isLoggedIn
@@ -37,7 +42,7 @@ export default function Header() {
       <SearchBar />
       <div className="header-button-container">
         <NotificationButton />
-        <DarkModeButton />
+        <DynamicDarkModeButton />
       </div>
       {isLogin ? (
         <div className="header-user-container">

--- a/src/hooks/useStorage.ts
+++ b/src/hooks/useStorage.ts
@@ -20,6 +20,7 @@ const useStorage = <T>({
       console.error(error)
     }
   })
+
   const setValue = (value: T) => {
     try {
       setStoredValue(value)
@@ -29,7 +30,6 @@ const useStorage = <T>({
     }
   }
 
-  console.log('storedValue', storedValue)
   return [storedValue, setValue]
 }
 

--- a/src/hooks/useStorage.ts
+++ b/src/hooks/useStorage.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
 
 type UseStorage<T> = {
   storageType: 'local' | 'session'
@@ -11,38 +11,26 @@ const useStorage = <T>({
   key,
   initialValue,
 }: UseStorage<T>): [T, (_value: T) => void] => {
-  const [storedValue, setStoredValue] = useState(initialValue)
-
-  useEffect(() => {
-    const storage = storageType === 'local' ? localStorage : sessionStorage
-    const item = storage.getItem(key)
-    if (item) {
-      setStoredValue(parse(item))
+  const storage = storageType === 'local' ? localStorage : sessionStorage
+  const [storedValue, setStoredValue] = useState(() => {
+    try {
+      const value = storage.getItem(key)
+      return value ? JSON.parse(value) : initialValue
+    } catch (error) {
+      console.error(error)
     }
-  }, [key, storageType])
-
-  useEffect(() => {
-    const storage = storageType === 'local' ? localStorage : sessionStorage
-    storage.setItem(key, JSON.stringify(storedValue))
-  }, [key, storageType, storedValue])
-
+  })
   const setValue = (value: T) => {
     try {
       setStoredValue(value)
+      storage.setItem(key, JSON.stringify(value))
     } catch (error) {
       console.error(error)
     }
   }
 
+  console.log('storedValue', storedValue)
   return [storedValue, setValue]
-}
-
-const parse = (storageValue: string) => {
-  try {
-    return JSON.parse(storageValue)
-  } catch {
-    return storageValue
-  }
 }
 
 export default useStorage


### PR DESCRIPTION
## - 목적
관련 이슈: #110 
Closes #110 
- 새로고침을 해도 로컬 스토리지가 초기화되지 않도록 문제를 수정했습니다.

<br>

## - 주요 변경 사항

- 다크모드 버튼이 [ssr되지 않는 Lazy Loading](https://nextjs.org/docs/pages/building-your-application/optimizing/lazy-loading#with-no-ssr) 되도록 해주었습니다.
- ssr이 되지 않기 때문에 처음부터 클라이언트에서 로컬스토리지 혹은 사용자 시스템에 접근할 수 있도록 수정했습니다.

## 기타 사항 (선택)

- 아주 정확한 원인은 모르겠지만, 기존에 서버에서의 darkMode값과 클라이언트에서 darkMode 값이 다른 것이 문제였던 것 같습니다.
- 아래와 같은 경고가 뜨고 있더라고요 (초기에 테스트했을 때는 제 시스템이 light라 서버와 클라이언트 값이 일치해서 저 경고를 못 봤고, 빌드에는 문제가 없어서 인지하지 못하고 넘어간 것 같습니다. 이번에는 시스템 환경을 다크모드로 변경해서 테스트했습니다.)
<img width="604" alt="스크린샷 2023-09-16 오후 10 32 17" src="https://github.com/prgrms-fe-devcourse/FEDC4_Price-PCC_DONGYOUNG/assets/91667853/f259f47a-ba61-4117-8f51-841828ab6e5b">

- 보아하니 서버에서는 로컬스토리지나 사용자 시스템 환경에 접근하지 못하기 때문에 코드 상 디폴트 값인 darkMode = false로 가지고 있고, 클라이언트에서는 darkMode를 저의 시스템 환경을 따라 darkMode = true로 읽기 때문에 생긴 문제 같았습니다.
- 그런데.. 서버에서 읽은 값이 다르더라도 클라이언트에서 스토리지에 있는 값을 잘 읽었다면 그거대로 렌더링을 해주면 될 텐데, 왜 끝에 다시 스토리지 값이 초기화되는지는 아직 잘 모르겠습니다.🥲 이것과는 관련이 없는 걸까요?

- 우선은 ssr이 되지 않도록 문제를 해결하긴 했는데, ssr이 되지 않아서 새로고침 시 맨 처음에는 잠시 라이트 모드 화면 (body 에 디폴트로 박아놓은 라이트 모드 클래스 때문에)이 깜빡 나타났다가 다크로 바뀌는 문제가 있습니다..  (이후 페이지 이동 시에는 괜찮습니다.)
- 이 문제는 또 열심히 해결책을 찾아보겠습니다.. (이런 문제 때문에 이 방법이 맞는 방법은 아닐 수도 있을 것 같습니다.. 좀 더 찾아볼게요)

- 경고는 해결했고 돌아가는 데 문제가 있는 건 아니라서, 우선 릴리즈 하고 추후 더 찾아봐도 될 것 같긴 합니다.. 배포하는 게 우선이다 싶다면 먼저 머지하도록 하겠습니다..!

- 구구절절 PR 읽어주셔서 감사합니다 😭

<br>

## - 스크린샷 (선택)
