### PR TITLE
:tada: 로그인 여부에 따른 반응적 헤더 구현 및 페이지이동 제한 적용(기능 구현 완료)

### DIFF
--- a/src/components/molcules/ModalDropdownList/ModalDropdownList.tsx
+++ b/src/components/molcules/ModalDropdownList/ModalDropdownList.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import Link from 'next/link'
-import { useRouter } from 'next/navigation'
 import { Text } from '@/components/atoms/Text'
 import APP_PATH from '@/config/paths'
 import { useLogout } from '@/hooks/useLogout'
@@ -9,20 +8,14 @@ import './index.scss'
 
 type PropsType = {
   userId: string
-  changeLoginState: (_value: boolean) => void
 }
 
-export default function ModalDropdownList({
-  userId,
-  changeLoginState,
-}: PropsType) {
-  const router = useRouter()
+export default function ModalDropdownList({ userId }: PropsType) {
   const { logout } = useLogout()
 
   const handleLogout = () => {
     logout()
-    changeLoginState(false)
-    router.push(APP_PATH.home())
+    location.reload()
   }
 
   return (

--- a/src/components/organisms/Header/Header.tsx
+++ b/src/components/organisms/Header/Header.tsx
@@ -31,6 +31,13 @@ export default function Header() {
     setDropdownClick(!dropdownClick)
   }
 
+  const preventPage = () => {
+    if (pathname === APP_PATH.postNew() || pathname.includes('user')) {
+      router.push(APP_PATH.home())
+      alert('로그인한 회원만 이용가능합니다.') // TODO: replace with toast
+    }
+  }
+
   useEffect(() => {
     token.current = Cookies.get(constants.AUTH_TOKEN)
     async function validate() {
@@ -43,16 +50,6 @@ export default function Header() {
       setIsLoggedIn(true)
       setCurrentUser(() => res)
     }
-
-    const preventPage = () => {
-      if (
-        pathname === APP_PATH.postNew() ||
-        pathname === APP_PATH.editProfile() ||
-        pathname === APP_PATH.userProfile(currentUser ? currentUser._id : '')
-      )
-        router.push(APP_PATH.home())
-    }
-
     token.current ? validate() : preventPage()
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [pathname])

--- a/src/components/organisms/Header/Header.tsx
+++ b/src/components/organisms/Header/Header.tsx
@@ -1,7 +1,9 @@
 'use client'
 
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
+import Cookies from 'js-cookie'
 import Link from 'next/link'
+import { usePathname, useRouter } from 'next/navigation'
 import Avatar from '@/components/atoms/Avatar'
 import DarkModeButton from '@/components/atoms/DarkModeButton'
 import ImageButton from '@/components/atoms/ImageButton'
@@ -10,27 +12,50 @@ import SearchBar from '@/components/atoms/SearchBar'
 import { Text } from '@/components/atoms/Text'
 import ModalDropdownList from '@/components/molcules/ModalDropdownList'
 import Assets from '@/config/assets'
+import { constants } from '@/config/constants'
 import APP_PATH from '@/config/paths'
-import { useCurrentUser } from '@/hooks/useCurrentUser'
+import { validateToken } from '@/services/auth'
+import User from '@/types/user'
 import './index.scss'
 
 export default function Header() {
-  const isCookie = useCurrentUser().isLoggedIn
-  const [isLogin, setIsLogin] = useState(isCookie)
-  const user = useCurrentUser().currentUser
   const [dropdownClick, setDropdownClick] = useState(false)
+  const [isLoggedIn, setIsLoggedIn] = useState(false)
+  const [currentUser, setCurrentUser] = useState<User>()
+
+  let token = useRef<string | undefined>(undefined)
+  const router = useRouter()
+  const pathname = usePathname()
 
   const handleDropdown = () => {
     setDropdownClick(!dropdownClick)
   }
 
-  const changeLoginState = (value: boolean) => {
-    setIsLogin(value)
-  }
-
   useEffect(() => {
-    changeLoginState(isCookie)
-  }, [isCookie])
+    token.current = Cookies.get(constants.AUTH_TOKEN)
+    async function validate() {
+      const res = await validateToken()
+      if (!res) {
+        Cookies.remove(constants.AUTH_TOKEN)
+        alert('올바르지 않은 토큰입니다.') // TODO: replace with toast
+        router.push(APP_PATH.login())
+      }
+      setIsLoggedIn(true)
+      setCurrentUser(() => res)
+    }
+
+    const preventPage = () => {
+      if (
+        pathname === APP_PATH.postNew() ||
+        pathname === APP_PATH.editProfile() ||
+        pathname === APP_PATH.userProfile(currentUser ? currentUser._id : '')
+      )
+        router.push(APP_PATH.home())
+    }
+
+    token.current ? validate() : preventPage()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [pathname])
 
   return (
     <div className="header-container color-bg--bg-1">
@@ -39,12 +64,12 @@ export default function Header() {
         <NotificationButton />
         <DarkModeButton />
       </div>
-      {isLogin ? (
+      {isLoggedIn ? (
         <div className="header-user-container">
           <Avatar
-            src={user ? user.image : Assets.PCCImage}
+            src={currentUser ? currentUser.image : Assets.PCCImage}
             size={3}
-            text={user ? user.fullName : '포청천'}
+            text={currentUser ? currentUser.fullName : '포청천'}
             textStyle={{
               fontWeight: 'bold',
               paddingLeft: '0.5rem',
@@ -57,10 +82,7 @@ export default function Header() {
             onClick={handleDropdown}
           />
           {dropdownClick && (
-            <ModalDropdownList
-              userId={user ? user._id : ''}
-              changeLoginState={changeLoginState}
-            />
+            <ModalDropdownList userId={currentUser ? currentUser._id : ''} />
           )}
         </div>
       ) : (


### PR DESCRIPTION
## - 목적
관련 이슈: #123

<br>

## - 주요 변경 사항
- 로그인을 하기 전이라면 로그인 / 회원가입 버튼이 헤더에 보입니다.
- 로그인을 했다면 메인 페이지로 이동되면서 프로필 이미지와 닉네임이 헤더에 보입니다.
- arrow 버튼을 클릭해 로그아웃을 했다면 어떤 페이지에 있든 로그아웃되면서 알림이 뜨고, 메인 페이지로 이동됩니다.(이때 헤더도 로그인 하기 전으로 바뀜)
- 로그인한 상태가 아니라면 계정 정보 수정, 글 작성 등 일부 페이지에 이동을 못합니다.(arrow 버튼 자체가 보이지 않기 때문, 로그아웃을 했다면 메인 페이지로 강제 이동되면서 헤더에서 arrow 버튼이 사라지기 때문)

## 기타 사항 (선택)
- useCurrentUser hook을 사용해서 해결하려고 했는데... 못했습니다. 
- useCurrentUser 코드를 참고해 useEffect를 사용해 pathname이 변할 때를 기준으로 rendering을 설정했습니다.
- 로그인을 할 경우 login -> / 으로 페이지 이동, 로그아웃을 할 경우 새로고침(reload) 으로 인해 반드시 useEffect 안의 코드가 실행됩니다.
- 원래는 쿠키 값을 dep에 넣어 기준값으로 삼으려고 했으나 이럴 경우 useEffect 안에 useCurrentUser 로직이 있어야 했습니다.
- useEffect안에 useCurrentUser를 그대로 넣으면 에러가 났고, 다른 방식으로 하려다보니 callback 오류, header 컴포넌트가 render 되지 않는 등의 오류들로 인해 결국 제 방식대로 코드를 구현하게 되었습니다. 
- 제대로 돌아가지만 코드가 많이 지저분해 추후 리팩토링이 필요해 보입니다... 
- 특히 useCurrentUser hook을 사용하고 싶은데.. 조언 부탁드립니다.. 

## 고민 
- 페이지 전환시 layout.tsx 파일에 있는 children만 render 되고, header와 navBar는 render 되지 않음
- header와 navBar를 render 하기 위해서는 state 값을 변화시켜줘야 함
- navBar 같은 경우 회원가입을 한 뒤 로그인을 하면 메인 페이지로 이동되면서 axios로 데이터를 불러오기 때문에 state가 변하면서 render가 됨
- header 같은 경우 header 내의 이벤트가 아닌 쿠키의 여부로 state를 변화시켜야 함
- 그러나 useEffect 의 dep에 Cookie.get을 넣어줘도 useEffect가 실행되지 않았음(쿠키여부로 useEffect 안의 코드를 실행시키고 싶음)

**너무 삽질을 오래하면서 다음 task에 지장이 생길 것 같았기에 여기서 마무리하고 기능만 제대로 돌아가게끔 한 뒤 제출합니다.**

<br>

## - 스크린샷 (선택)
![ezgif com-video-to-gif (4)](https://github.com/prgrms-fe-devcourse/FEDC4_Price-PCC_DONGYOUNG/assets/83554018/eba63e09-f5d9-45cc-9531-37e78cad7c21)

