### PR TITLE
:tada: 게시글 수정 페이지

### DIFF
--- a/src/app/(root)/(routes)/post/[postId]/modify/page.tsx
+++ b/src/app/(root)/(routes)/post/[postId]/modify/page.tsx
@@ -1,0 +1,23 @@
+import React from 'react'
+import ModifyPostPageTemplate from '@/components/templates/ModifyPostPageTemplate'
+import { getPostDetail } from '@/services/post'
+import Post from '@/types/post'
+
+async function getPostData(postId: string): Promise<Post> {
+  const res = await getPostDetail(postId)
+  const { post } = res
+  const { title, description } = await JSON.parse(post.title)
+  post.title = title
+  post.description = description
+  return post
+}
+
+export default async function PostModifyPage({
+  params: { postId },
+}: {
+  params: { postId: string }
+}) {
+  const postData = await getPostData(postId)
+
+  return <ModifyPostPageTemplate postData={postData} />
+}

--- a/src/app/api/posts/update/route.ts
+++ b/src/app/api/posts/update/route.ts
@@ -9,7 +9,6 @@ export async function PUT(request: Request) {
   formData.append('channelId', channelId)
 
   const { token } = useServerCookie()
-  console.log(formData, 'formData')
   try {
     const { data } = await apiServer.put(`/posts/update`, formData, {
       headers: {

--- a/src/app/api/posts/update/route.ts
+++ b/src/app/api/posts/update/route.ts
@@ -1,0 +1,27 @@
+import { NextResponse } from 'next/server'
+import { Environment } from '@/config/environments'
+import { useServerCookie } from '@/hooks/useServerCookie'
+import { apiServer } from '@/lib/axiosSever'
+
+export async function PUT(request: Request) {
+  const formData = await request.formData()
+  const channelId = Environment.channelId()
+  formData.append('channelId', channelId)
+
+  const { token } = useServerCookie()
+  console.log(formData, 'formData')
+  try {
+    const { data } = await apiServer.put(`/posts/update`, formData, {
+      headers: {
+        Authorization: 'Bearer ' + token,
+        'Content-Type': 'multipart/form-data',
+      },
+    })
+    return NextResponse.json(data)
+  } catch (error: any) {
+    return NextResponse.json(
+      { error: error.response.data.message },
+      { status: error.response.status },
+    )
+  }
+}

--- a/src/components/atoms/Quill/Quill.tsx
+++ b/src/components/atoms/Quill/Quill.tsx
@@ -10,12 +10,14 @@ const ReactQuill = dynamic(() => import('react-quill'), {
 
 type QuillProps = {
   onEdit?: (_contents: string) => void
+  defaultValue?: string
 }
 
-export default function Quill({ onEdit }: QuillProps) {
+export default function Quill({ onEdit, defaultValue }: QuillProps) {
   return (
     <div>
       <ReactQuill
+        defaultValue={defaultValue}
         className="quill"
         onChange={onEdit}
         modules={modules}

--- a/src/components/molcules/file-picker/index.scss
+++ b/src/components/molcules/file-picker/index.scss
@@ -1,4 +1,7 @@
+@import '@/styles/variables.scss';
+
 .file-picker {
+  position: relative;
   display: flex;
   flex-direction: column;
   flex-wrap: wrap;
@@ -62,5 +65,31 @@
       border-radius: 5px;
       background-color: none;
     }
+  }
+}
+
+.file-picker__delete-button {
+  width: 2rem;
+  height: 2rem;
+  position: absolute;
+  top: 0;
+  right: 0;
+  font-weight: bold;
+  @include themed() {
+    background-color: t(primary-1);
+    border: 3px solid t(gray-5);
+    color: t(gray-5);
+  }
+  border: none;
+  cursor: pointer;
+  z-index: 5;
+
+  &.hidden {
+    display: none;
+  }
+
+  &:hover {
+    opacity: 0.8;
+    transition: opacity 0.2s ease-in-out;
   }
 }

--- a/src/components/molcules/file-picker/index.tsx
+++ b/src/components/molcules/file-picker/index.tsx
@@ -17,7 +17,7 @@ type FilePickerProps = {
   width?: number
   height?: number
   defaultValue?: string
-  onChange?: (_files: FileList) => void
+  onChange?: (_files: FileList | null) => void
   className?: string
 }
 
@@ -32,25 +32,26 @@ export default function FilePicker({
   className,
 }: FilePickerProps) {
   useEffect(() => {})
+
   const [_files, setFiles] = useState<FileList | null>(null)
   const [thumbNail, setThumbNail] = useState<string>(defaultValue)
   const dropDownRef = useRef<HTMLDivElement | null>(null)
   const fileUploadRef = useRef<HTMLInputElement | null>(null)
 
-  const createNewThumbNailImage = useCallback((files: FileList) => {
-    const blob = new Blob([files[0]], {
-      type: files[0].type,
+  const createNewThumbNailImage = useCallback((newFiles: FileList) => {
+    const blob = new Blob([newFiles[0]], {
+      type: newFiles[0].type,
     })
 
     return URL.createObjectURL(blob)
   }, [])
 
-  const { targetRef } = useDragging(dropDownRef, (_newFiles) => {
-    setFiles(_newFiles)
-    const newThumbNailImage = createNewThumbNailImage(_newFiles)
+  const { targetRef } = useDragging(dropDownRef, (newFiles) => {
+    setFiles(newFiles)
+    const newThumbNailImage = createNewThumbNailImage(newFiles)
     setThumbNail(newThumbNailImage)
     if (onChange) {
-      onChange(_newFiles)
+      onChange(newFiles)
     }
   })
 
@@ -78,6 +79,14 @@ export default function FilePicker({
     }
   }
 
+  const handleDeleteImage = () => {
+    setFiles(null)
+    setThumbNail('')
+    if (onChange) {
+      onChange(null)
+    }
+  }
+
   return (
     <div
       className="file-picker"
@@ -85,7 +94,7 @@ export default function FilePicker({
       style={{
         width: `${width}rem`,
         height: `${height}rem`,
-        border: `${hasThumbNailImage && 'none'}`,
+        border: `${hasThumbNailImage ? 'none' : ''}`,
       }}
     >
       <label className="file-picker__label" htmlFor="file-picker">
@@ -127,6 +136,7 @@ export default function FilePicker({
       <button
         disabled={disabled}
         onClick={handleOnClickUploadBtn}
+        type="button"
         className="file-picker__button"
       >
         {!hasThumbNailImage && (
@@ -138,6 +148,13 @@ export default function FilePicker({
             height={45}
           />
         )}
+      </button>
+      <button
+        className={`file-picker__delete-button ${thumbNail ? '' : 'hidden'}`}
+        type="button"
+        onClick={handleDeleteImage}
+      >
+        X
       </button>
     </div>
   )

--- a/src/components/molcules/file-picker/index.tsx
+++ b/src/components/molcules/file-picker/index.tsx
@@ -16,6 +16,7 @@ type FilePickerProps = {
   disabled?: boolean
   width?: number
   height?: number
+  defaultValue?: string
   onChange?: (_files: FileList) => void
   className?: string
 }
@@ -26,12 +27,13 @@ export default function FilePicker({
   disabled,
   width = 5,
   height = 5,
+  defaultValue = '',
   onChange,
   className,
 }: FilePickerProps) {
   useEffect(() => {})
   const [_files, setFiles] = useState<FileList | null>(null)
-  const [thumbNail, setThumbNail] = useState<string>('')
+  const [thumbNail, setThumbNail] = useState<string>(defaultValue)
   const dropDownRef = useRef<HTMLDivElement | null>(null)
   const fileUploadRef = useRef<HTMLInputElement | null>(null)
 

--- a/src/components/templates/ModifyPostPageTemplate/ModifyPostPageTemplate.tsx
+++ b/src/components/templates/ModifyPostPageTemplate/ModifyPostPageTemplate.tsx
@@ -1,0 +1,84 @@
+'use client'
+
+import { useLayoutEffect } from 'react'
+import { Button } from '@/components/atoms/Button'
+import Input from '@/components/atoms/Input'
+import Quill from '@/components/atoms/Quill'
+import FilePicker from '@/components/molcules/file-picker'
+import { useModifyPostForm } from '@/hooks/useModifyPostForm'
+import Post from '@/types/post'
+import './index.scss'
+
+type ModifyPostPageTemplateProps = {
+  postData: Post
+}
+
+export default function ModifyPostPageTemplate({
+  postData,
+}: ModifyPostPageTemplateProps) {
+  const { register, onSubmit, titleError, setValue } = useModifyPostForm()
+
+  useLayoutEffect(() => {
+    console.log(postData, 'postData')
+    setValue('postId', postData._id)
+    setValue('title', postData.title)
+    setValue('description', postData.description)
+    setValue('imageSelective', {
+      image: postData.image,
+      imageToDeletePublicId: postData.imagePublicId,
+    })
+  }, [postData, setValue])
+
+  return (
+    <form className="upload-page" onSubmit={onSubmit}>
+      <Input
+        type="text"
+        placeholder="제목을 입력해주세요"
+        variant={titleError ? 'error' : 'clear'}
+        outline="underbar"
+        style={{
+          fontSize: '2.5rem',
+          fontWeight: 'bold',
+        }}
+        {...register('title', {
+          required: '제목을 입력해주세요',
+        })}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter') {
+            e.preventDefault()
+          }
+        }}
+      />
+      <Quill
+        defaultValue={postData.description}
+        onEdit={(text) => {
+          setValue('description', text)
+        }}
+      />
+      <div className="file-picker-container">
+        <FilePicker
+          width={20}
+          height={10}
+          defaultValue={postData.image}
+          onChange={(file) => {
+            setValue('imageSelective', {
+              image: file[0],
+              imageToDeletePublicId: undefined,
+            })
+          }}
+        />
+      </div>
+      <div className="submit-button-container">
+        <Button
+          text="완료"
+          variant="default"
+          isShadowed={true}
+          rounded="rounded-md"
+          width={12}
+          height={3}
+          type="submit"
+        />
+      </div>
+    </form>
+  )
+}

--- a/src/components/templates/ModifyPostPageTemplate/ModifyPostPageTemplate.tsx
+++ b/src/components/templates/ModifyPostPageTemplate/ModifyPostPageTemplate.tsx
@@ -1,10 +1,14 @@
 'use client'
 
-import { useLayoutEffect } from 'react'
+import { useLayoutEffect, useEffect } from 'react'
+import { useRouter } from 'next/navigation'
 import { Button } from '@/components/atoms/Button'
 import Input from '@/components/atoms/Input'
 import Quill from '@/components/atoms/Quill'
+import { notify } from '@/components/atoms/Toast'
 import FilePicker from '@/components/molcules/file-picker'
+import APP_PATH from '@/config/paths'
+import { useCurrentUser } from '@/hooks/useCurrentUser'
 import { useModifyPostForm } from '@/hooks/useModifyPostForm'
 import Post from '@/types/post'
 import './index.scss'
@@ -17,9 +21,10 @@ export default function ModifyPostPageTemplate({
   postData,
 }: ModifyPostPageTemplateProps) {
   const { register, onSubmit, titleError, setValue } = useModifyPostForm()
+  const { currentUser } = useCurrentUser()
+  const router = useRouter()
 
   useLayoutEffect(() => {
-    console.log(postData, 'postData')
     setValue('postId', postData._id)
     setValue('title', postData.title)
     setValue('description', postData.description)
@@ -28,6 +33,13 @@ export default function ModifyPostPageTemplate({
       imageToDeletePublicId: postData.imagePublicId,
     })
   }, [postData, setValue])
+
+  useEffect(() => {
+    if (currentUser && postData.author._id !== currentUser?._id) {
+      router.push(APP_PATH.postDetail(postData._id))
+      notify('warning', '올바르지 않은 접근입니다.')
+    }
+  }, [currentUser, postData, router])
 
   return (
     <form className="upload-page" onSubmit={onSubmit}>
@@ -62,8 +74,8 @@ export default function ModifyPostPageTemplate({
           defaultValue={postData.image}
           onChange={(file) => {
             setValue('imageSelective', {
-              image: file[0],
-              imageToDeletePublicId: undefined,
+              image: file?.[0] ?? null,
+              imageToDeletePublicId: postData.imagePublicId,
             })
           }}
         />

--- a/src/components/templates/ModifyPostPageTemplate/index.scss
+++ b/src/components/templates/ModifyPostPageTemplate/index.scss
@@ -1,0 +1,17 @@
+.upload-page {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+
+  padding: 1.5rem;
+}
+
+.file-picker-container {
+  margin: 2rem 0 2rem auto;
+}
+
+.submit-button-container {
+  margin-left: auto;
+}

--- a/src/components/templates/ModifyPostPageTemplate/index.tsx
+++ b/src/components/templates/ModifyPostPageTemplate/index.tsx
@@ -1,0 +1,3 @@
+import { default as ModifyPostPageTemplate } from './ModifyPostPageTemplate'
+
+export default ModifyPostPageTemplate

--- a/src/components/templates/NewPostPageTemplate/NewPostPageTemplate.tsx
+++ b/src/components/templates/NewPostPageTemplate/NewPostPageTemplate.tsx
@@ -39,7 +39,7 @@ export default function NewPostPageTemplate() {
           width={20}
           height={10}
           onChange={(file) => {
-            setValue('image', file[0])
+            setValue('image', file?.[0]!)
           }}
         />
       </div>

--- a/src/hooks/useModifyPostForm.ts
+++ b/src/hooks/useModifyPostForm.ts
@@ -1,0 +1,54 @@
+import { useForm } from 'react-hook-form'
+import { useRouter } from 'next/navigation'
+import { notify } from '@/components/atoms/Toast'
+import APP_PATH from '@/config/paths'
+import { putUserPost } from '@/services/post'
+
+export interface ModifyFormData {
+  title: string
+  description: string
+  postId: string
+  imageSelective: {
+    image: File | string | null | undefined
+    imageToDeletePublicId: string | undefined
+  }
+}
+
+export const useModifyPostForm = () => {
+  const { register, handleSubmit, formState, setValue } =
+    useForm<ModifyFormData>()
+  const router = useRouter()
+
+  const onSubmit = async ({
+    title,
+    description,
+    postId,
+    imageSelective,
+  }: ModifyFormData) => {
+    console.log(title, description, postId, imageSelective, 'title')
+    try {
+      const res = await putUserPost({
+        title,
+        description,
+        postId,
+        imageSelective,
+      })
+
+      if (res) {
+        notify('success', '게시글이 성공적으로 등록되었습니다.')
+        router.push(APP_PATH.postDetail(postId))
+      }
+    } catch (e) {
+      notify('error', '게시글 등록에 실패했습니다.')
+    }
+  }
+
+  return {
+    register,
+    onSubmit: handleSubmit(onSubmit),
+    titleError: formState.errors.title?.message,
+    descriptionError: formState.errors.description?.message,
+    imageError: formState.errors.imageSelective?.message,
+    setValue,
+  }
+}

--- a/src/hooks/useModifyPostForm.ts
+++ b/src/hooks/useModifyPostForm.ts
@@ -25,7 +25,6 @@ export const useModifyPostForm = () => {
     postId,
     imageSelective,
   }: ModifyFormData) => {
-    console.log(title, description, postId, imageSelective, 'title')
     try {
       const res = await putUserPost({
         title,

--- a/src/services/post/index.ts
+++ b/src/services/post/index.ts
@@ -1,3 +1,4 @@
+import { ModifyFormData } from '@/hooks/useModifyPostForm'
 import { apiClient } from '@/lib/axios'
 
 interface PostUserBody {
@@ -27,4 +28,45 @@ export const getPostDetail = async (id: string) => {
   } catch (e) {
     if (e instanceof Error) throw new Error(e.message)
   }
+}
+
+export const putUserPost = async (body: ModifyFormData) => {
+  const title = JSON.stringify({
+    title: body.title,
+    description: body.description,
+  })
+  console.log(body, 'body')
+  const formData = new FormData()
+  formData.append('title', title)
+  formData.append('postId', body.postId)
+
+  // 기존 이미지가 있고, 변경 없을 때
+  if (typeof body.imageSelective.image === 'string') {
+    formData.append('image', '')
+  }
+  // 기존 이미지가 있든 없든 새로운 이미지가 있을 때
+  else if (body.imageSelective.image instanceof File) {
+    formData.append('image', body.imageSelective.image)
+  }
+  //  기존 이미지가 없고, 새로운 이미지가 없을 때
+  else if (
+    !body.imageSelective.image &&
+    !body.imageSelective.imageToDeletePublicId
+  ) {
+    formData.append('image', '')
+  }
+  // 기존 이미지가 있고, 기존 이미지를 삭제할 때
+  if (body.imageSelective.imageToDeletePublicId && !body.imageSelective.image) {
+    formData.append(
+      'imageToDeletePublicId',
+      body.imageSelective.imageToDeletePublicId,
+    )
+  }
+
+  const { data } = await apiClient.put('/api/posts/update', formData, {
+    headers: {
+      'Content-Type': 'multipart/form-data',
+    },
+  })
+  return data
 }

--- a/src/services/post/index.ts
+++ b/src/services/post/index.ts
@@ -35,7 +35,6 @@ export const putUserPost = async (body: ModifyFormData) => {
     title: body.title,
     description: body.description,
   })
-  console.log(body, 'body')
   const formData = new FormData()
   formData.append('title', title)
   formData.append('postId', body.postId)


### PR DESCRIPTION
## - 목적
관련 이슈: #155

<br>

## - 주요 변경 사항

- 게시글 수정 페이지 레이아웃
- 기존 정보 불러오기 및 수정 로직 작성
- file-picker 삭제 기능 추가
- 내 게시글이 아닌 경우에 대한 접근 제한

## 기타 사항 (선택)

- @khj0426 상세 페이지에 내 게시글인 경우 수정 페이지로 이동하는 기능이 있나요??

<br>

## - 스크린샷 (선택)
