### PR TITLE
:tada: 유저 카드형 프로필 컴포넌트 구현

### DIFF
--- a/src/components/organisms/CardUserItem/CardUserItem.tsx
+++ b/src/components/organisms/CardUserItem/CardUserItem.tsx
@@ -1,0 +1,51 @@
+import Image from 'next/image'
+import Link from 'next/link'
+import { Card } from '@/components/atoms/Card'
+import { Text } from '@/components/atoms/Text'
+import Assets from '@/config/assets'
+import APP_PATH from '@/config/paths'
+import './index.scss'
+
+type CardUserPropsType = {
+  _id: string
+  image: string
+  fullName: string
+  followers: string[]
+  following: string[]
+}
+
+export default function CardUserItem({
+  _id,
+  image,
+  fullName,
+  followers,
+  following,
+}: CardUserPropsType) {
+  return (
+    <Card>
+      <Link href={APP_PATH.userProfile(_id)}>
+        <div className="card-user-container">
+          <Image
+            width={100}
+            height={100}
+            src={image || Assets.PCCImage}
+            alt="profile-image"
+            style={{ borderRadius: '50%' }}
+          />
+          <Text textStyle="heading1-bold">{fullName}</Text>
+          <div className="follow-container">
+            <MultiText title="팔로워" count={followers}></MultiText>
+            <MultiText title="팔로잉" count={following}></MultiText>
+          </div>
+        </div>
+      </Link>
+    </Card>
+  )
+}
+
+const MultiText = ({ title, count }: { title: string; count: string[] }) => (
+  <div className="follow-count-container">
+    <Text textStyle="heading2">{title}</Text>
+    <Text textStyle="heading2-bold">{count.length}</Text>
+  </div>
+)

--- a/src/components/organisms/CardUserItem/index.scss
+++ b/src/components/organisms/CardUserItem/index.scss
@@ -1,0 +1,21 @@
+@mixin centerAlign {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.card-user-container {
+  @include centerAlign();
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.follow-container {
+  @include centerAlign();
+  gap: 1rem;
+}
+
+.follow-count-container {
+  @include centerAlign();
+  gap: 0.4rem;
+}

--- a/src/components/organisms/CardUserItem/index.stories.ts
+++ b/src/components/organisms/CardUserItem/index.stories.ts
@@ -1,0 +1,20 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import CardUserItem from '.'
+
+const meta = {
+  title: 'Component/CardUserItem',
+  component: CardUserItem,
+} satisfies Meta<typeof CardUserItem>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Primary: Story = {
+  args: {
+    _id: '테스트 아이디',
+    image: 'https://picsum.photos/200/200',
+    fullName: '테스트',
+    followers: ['12', '1', '123'],
+    following: ['12', '1', '123'],
+  },
+}

--- a/src/components/organisms/CardUserItem/index.ts
+++ b/src/components/organisms/CardUserItem/index.ts
@@ -1,0 +1,1 @@
+export { default } from './CardUserItem'


### PR DESCRIPTION
## - 목적
관련 이슈: #170

<br>

## - 주요 변경 사항
- 검색페이지에서 사용되는 유저 프로필 카드형 컴포넌트를 구현했습니다.

## 기타 사항 (선택)
- type 폴더에 있는 user interface를 수정하려고 했으나 이 부분은 민희님께서 맡으신 팔로우 부분과 밀접한 관련이 있어서 결국 수정하지 않았습니다.(자체적 type 만들어 해결함)

<br>

## - 스크린샷 (선택)
<img width="1280" alt="image" src="https://github.com/prgrms-fe-devcourse/FEDC4_Price-PCC_DONGYOUNG/assets/83554018/1b111a4f-91ac-49a8-8240-3227f28f9064">

