### PR TITLE
:sparkles: minor layout 조정

### DIFF
--- a/src/components/atoms/Avatar/index.tsx
+++ b/src/components/atoms/Avatar/index.tsx
@@ -98,7 +98,6 @@ const Description = ({
       style={{
         color: textColor,
         ...textStyle,
-        width: '200px',
         whiteSpace: 'nowrap',
         overflow: 'hidden',
         textOverflow: 'ellipsis',
@@ -107,7 +106,6 @@ const Description = ({
       <div
         style={{
           ...textStyle,
-          width: '200px',
           whiteSpace: 'nowrap',
           overflow: 'hidden',
           textOverflow: 'ellipsis',
@@ -118,7 +116,6 @@ const Description = ({
       <div
         style={{
           ...textStyle,
-          width: '200px',
           whiteSpace: 'nowrap',
           overflow: 'hidden',
           textOverflow: 'ellipsis',

--- a/src/components/organisms/Header/Header.tsx
+++ b/src/components/organisms/Header/Header.tsx
@@ -49,7 +49,7 @@ export default function Header() {
             text={cachedCurrentUser ? cachedCurrentUser.fullName : ''}
             textStyle={{
               fontWeight: 'bold',
-              paddingLeft: '0.5rem',
+              padding: '0 0.5rem 0 0.5rem',
               wordBreak: 'keep-all',
             }}
           />

--- a/src/components/organisms/Header/index.scss
+++ b/src/components/organisms/Header/index.scss
@@ -12,9 +12,11 @@
   align-items: center;
   border-radius: 1rem 0 0 1rem;
   width: calc(100% - 20rem);
+  min-width: calc(1040px - 320px - 2rem);
+  margin-left: 2rem;
   height: 5rem;
   position: fixed;
-  z-index: 1;
+  z-index: 100;
   padding: 0 3rem 0 2rem;
   top: 0%;
   box-shadow: 0 0 0.5rem 0 rgba(0, 0, 0, 0.2);
@@ -43,7 +45,6 @@
   &:hover {
     cursor: pointer;
   }
-  gap: 1rem;
 
   .image-button__image {
     object-fit: contain;

--- a/src/components/organisms/NavBar/index.scss
+++ b/src/components/organisms/NavBar/index.scss
@@ -1,9 +1,9 @@
 @import '/src/styles/global-layout.scss';
 
 .nav-container {
-  width: fit-content;
   padding: 0 2rem;
   height: 100%;
+  width: 320px;
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -11,12 +11,14 @@
   position: fixed;
   box-shadow: 0 0 0.5rem 0 rgba(0, 0, 0, 0.2);
   top: 0%;
+  z-index: 100;
 
   .image-button {
     padding: 2rem 0;
   }
 
   .image-button__image {
+    width: -moz-fit-content;
     width: fit-content;
     height: 4rem;
     object-fit: contain;

--- a/src/styles/layout.scss
+++ b/src/styles/layout.scss
@@ -1,3 +1,5 @@
+@import '@/styles/variables.scss';
+
 .main-container {
   width: calc(100% - 20rem);
   height: auto;
@@ -12,4 +14,10 @@ main {
   align-items: center;
   padding: 3rem;
   z-index: 0;
+}
+
+body {
+  min-width: 1040px;
+  display: flex;
+  flex: row;
 }

--- a/src/styles/layout.scss
+++ b/src/styles/layout.scss
@@ -20,4 +20,8 @@ body {
   min-width: 1040px;
   display: flex;
   flex: row;
+
+  &::-webkit-scrollbar {
+    display: none;
+  }
 }


### PR DESCRIPTION
## - 목적
관련 이슈: #159 
-

<br>

## - 주요 변경 사항

- nav, header 간 간격 조정
- 전체 화면의 min-width 설정 (1040px)
- 기타 자잘한 스타일 조정
- body의 스크롤 바 삭제

## 기타 사항 (선택)

- 전체 스크롤 바가.. 각 유저 페이지 등에 접속 할 때 스크롤바가 없다가 -> CSR 과정에서 글이 로딩되며 스크롤바가 생기는 과정에서 따닥 하면서 새로 페인트 되는 과정이 보기 안 좋아 일단 삭제했습니다. 의견 있으면 부탁드려요.
- 그래서 infinite scroll에서 마지막에 도달했을 경우 마지막 페이지입니다. 정도가 끝에 표시되면 어떨까 생각했습니다. 요것도 의견 부탁드려요. 

<br>

## - 스크린샷 (선택)
