### PR TITLE
:tada: html 태그 파싱

### DIFF
--- a/src/app/(root)/(routes)/(home)/page.tsx
+++ b/src/app/(root)/(routes)/(home)/page.tsx
@@ -9,5 +9,7 @@ export default function Home() {
 
   const { observerElem } = useInfiniteScroll({ fetchNextPage, hasNextPage })
 
-  return <CardGridTemplate postDatas={data?.pages.flat()} ref={observerElem} />
+  let posts = data?.pages.flat()
+
+  return <CardGridTemplate postDatas={posts} ref={observerElem} />
 }

--- a/src/components/organisms/CardPostItem/CardPostItem.tsx
+++ b/src/components/organisms/CardPostItem/CardPostItem.tsx
@@ -8,6 +8,7 @@ import { LikeDislikeCount } from '@/components/molcules/LikeDislikeCount'
 import APP_PATH from '@/config/paths'
 import { getPostDetail } from '@/services/post'
 import Post from '@/types/post'
+import htmlTagParser from '@/utils/htmlTagParser'
 import './index.scss'
 
 export type CardPostItemProps = Pick<
@@ -59,7 +60,7 @@ export default function CardPostItem({
                 overflow: 'hidden',
               }}
             >
-              {description}
+              {htmlTagParser(description)}
             </Text>
           </Link>
         )}

--- a/src/components/organisms/userPostsGrid/userPostsGrid.tsx
+++ b/src/components/organisms/userPostsGrid/userPostsGrid.tsx
@@ -9,7 +9,10 @@ export default function UserPostsGrid({ userId }: { userId: string }) {
   const { data, fetchNextPage, hasNextPage } = useGetUserPosts(userId)
   const { observerElem } = useInfiniteScroll({ fetchNextPage, hasNextPage })
 
-  const posts = data?.pages.flat()
+  const posts = data?.pages.flat().map((post) => {
+    const { title, description } = JSON.parse(post.title)
+    return { ...post, title, description }
+  })
 
   return <CardGridTemplate postDatas={posts} ref={observerElem} />
 }

--- a/src/utils/htmlTagParser.ts
+++ b/src/utils/htmlTagParser.ts
@@ -1,0 +1,19 @@
+type HTMLTagParserType = (_htmlString: string) => string | null
+
+const elementsToCheck = ['p', 'h6', 'h5', 'h4', 'h3', 'h2', 'h1']
+
+const htmlTagParser: HTMLTagParserType = (htmlString) => {
+  const parser = new DOMParser()
+  const doc = parser.parseFromString(htmlString, 'text/html')
+
+  for (const elementName of elementsToCheck) {
+    const element = doc.querySelector(elementName)
+    if (element) {
+      return element.textContent
+    }
+  }
+
+  return null
+}
+
+export default htmlTagParser


### PR DESCRIPTION
## - 목적
관련 이슈: #183 
-

<br>

## - 주요 변경 사항

- html tag를 파싱해서 텍스트만 추출하도록 했습니다. (p -> h6 -> ... -> h1 순으로 확인)
- post card 컴포넌트에 적용시켜 두었습니다.

## 기타 사항 (선택)

-

<br>

## - 스크린샷 (선택)
