### PR TITLE
🐛 게시글 검색페이지, 유저 프로필 페이지에서 현재 채널의 상태만 반영

### DIFF
--- a/src/app/api/posts/author/route.ts
+++ b/src/app/api/posts/author/route.ts
@@ -1,5 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
+import { Environment } from '@/config/environments'
 import { apiServer } from '@/lib/axiosSever'
+import Post from '@/types/post'
 
 export async function GET(req: NextRequest) {
   const authorId = req.nextUrl.searchParams.get('authorId') ?? 'undefined'
@@ -10,7 +12,10 @@ export async function GET(req: NextRequest) {
     const { data } = await apiServer.get(
       `/posts/author/${authorId}?offset=${offset}&limit=${limit}`,
     )
-    return NextResponse.json(data)
+
+    return NextResponse.json(
+      data.filter((post: Post) => post.channel._id === Environment.channelId()),
+    )
   } catch (error: any) {
     return NextResponse.json(
       { error: error.response.data.message },

--- a/src/app/api/search/all/[keyword]/route.ts
+++ b/src/app/api/search/all/[keyword]/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest } from 'next/server'
+import { Environment } from '@/config/environments'
 
 async function fetchSearchData(keyword: string) {
   const decodeKeyword = decodeURI(keyword)
@@ -28,7 +29,15 @@ export async function GET(req: NextRequest) {
 
   try {
     const data = await fetchSearchData(keyword)
-    return new Response(JSON.stringify(data), { status: 200 })
+    return new Response(
+      JSON.stringify(
+        data.filter(
+          ({ channel }: { channel: string }) =>
+            channel === Environment.channelId(),
+        ),
+      ),
+      { status: 200 },
+    )
   } catch (error: any) {
     return new Response(JSON.stringify({ error: error.message }), {
       status: Number(JSON.stringify({ error: error.status })),

--- a/src/components/organisms/PostGrid/PostGrid.tsx
+++ b/src/components/organisms/PostGrid/PostGrid.tsx
@@ -12,13 +12,21 @@ export default function CardGridTemplate({ data }: PropsType) {
   return (
     <div className="card-grid-container">
       {data?.map(
-        ({ _id, image, author, title, description }: CardPostItemProps) => (
+        ({
+          _id,
+          image,
+          author,
+          title,
+          description,
+          likes,
+        }: CardPostItemProps) => (
           <CardPostItem
             key={_id}
             _id={_id}
             image={image}
             author={author}
             title={title}
+            likes={likes}
             description={description}
           />
         ),

--- a/src/components/organisms/UserDetailCard/UserDetailCard.tsx
+++ b/src/components/organisms/UserDetailCard/UserDetailCard.tsx
@@ -1,6 +1,7 @@
 import Avatar from '@/components/atoms/Avatar'
 import { Card } from '@/components/atoms/Card'
 import { Text } from '@/components/atoms/Text'
+import { Environment } from '@/config/environments'
 import { getUserDetail } from '@/services/user'
 import User from '@/types/user'
 import './index.scss'
@@ -13,13 +14,15 @@ async function getUserData(userId: string): Promise<User> {
 
 export default async function UserDetailCard({ userId }: { userId: string }) {
   const userData = await getUserData(userId)
-
+  const userCurChannelPostLength = userData?.posts?.filter(
+    (post) => String(post.channel) === Environment.channelId(),
+  ).length
   return (
     <Card className="user-detail_card">
       <Avatar size={10} />
       <Text textStyle="heading1-bold">{userData?.fullName}</Text>
       <Follows userData={userData} />
-      <InfoCount text="게시글" number={userData?.posts?.length.toString()} />
+      <InfoCount text="게시글" number={userCurChannelPostLength?.toString()} />
     </Card>
   )
 }

--- a/src/components/organisms/userPostsGrid/userPostsGrid.tsx
+++ b/src/components/organisms/userPostsGrid/userPostsGrid.tsx
@@ -3,13 +3,19 @@
 import CardGridTemplate from '@/components/templates/CardGridTemplate'
 import { useInfiniteScroll } from '@/hooks/useInfiniteScroll'
 import useGetUserPosts from '@/queries/posts'
+import Post from '@/types/post'
 import './index.scss'
 
 export default function UserPostsGrid({ userId }: { userId: string }) {
   const { data, fetchNextPage, hasNextPage } = useGetUserPosts(userId)
   const { observerElem } = useInfiniteScroll({ fetchNextPage, hasNextPage })
 
-  const posts = data?.pages.flat()
+  const uniquePosts = data?.pages.flat().reduce((unique, post) => {
+    if (!unique.some((uniquePost: Post) => uniquePost._id === post._id)) {
+      unique.push(post)
+    }
+    return unique
+  }, [])
 
-  return <CardGridTemplate postDatas={posts} ref={observerElem} />
+  return <CardGridTemplate postDatas={uniquePosts} ref={observerElem} />
 }


### PR DESCRIPTION
## - 목적
관련 이슈: #186 
-

<br>

## - 주요 변경 사항

- 검색 페이지에서 현재 채널의 ID를 받아서 포스트 들 중 같은 채널의 포스트만 반환하게 수정했어요
- 프로필 페이지에서 유저가 현재 채널에서 작성한 포스트만 나타나게 바뀌었습니다.

## 기타 사항 (선택)

-

<br>

## - 스크린샷 (선택)

![image](https://github.com/prgrms-fe-devcourse/FEDC4_Price-PCC_DONGYOUNG/assets/59411107/e3c294a3-a325-4608-ba8b-f2569dd736e0)


![image](https://github.com/prgrms-fe-devcourse/FEDC4_Price-PCC_DONGYOUNG/assets/59411107/20954ba1-a11c-4d0e-9a6a-51e58b750129)
