### PR TITLE
✨ 피드백 반영

### DIFF
--- a/src/components/atoms/SearchBar/SearchBar.tsx
+++ b/src/components/atoms/SearchBar/SearchBar.tsx
@@ -18,9 +18,10 @@ export default function SearchBar() {
 
   const handleEnterKeyPress = (e: React.KeyboardEvent<HTMLInputElement>) => {
     if (e.key === 'Enter') {
-      keyword === ''
+      keyword.trim() === ''
         ? router.push(APP_PATH.home())
-        : router.push(APP_PATH.search(keyword))
+        : router.push(APP_PATH.search(keyword.trim()))
+      sessionStorage.setItem('category', 'post')
     }
   }
 

--- a/src/components/organisms/PostGrid/PostGrid.tsx
+++ b/src/components/organisms/PostGrid/PostGrid.tsx
@@ -8,7 +8,7 @@ import './index.scss'
 type PropsType = {
   data: Post[] | undefined
 }
-export default function CardGridTemplate({ data }: PropsType) {
+export default function PostGrid({ data }: PropsType) {
   return (
     <div className="card-grid-container">
       {data?.map(

--- a/src/components/templates/SearchPageTemplate/SearchPageTemplate.tsx
+++ b/src/components/templates/SearchPageTemplate/SearchPageTemplate.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { Text } from '@/components/atoms/Text'
 import PostGrid from '@/components/organisms/PostGrid'
 import UserGrid from '@/components/organisms/UserGrid'
@@ -18,13 +18,21 @@ export default function SearchPageTemplate({ data }: dataType) {
   const [postClick, setPostClick] = useState(true)
   const [userClick, setUserClick] = useState(false)
 
+  useEffect(() => {
+    sessionStorage.getItem('category') === 'post'
+      ? handleClick('post')
+      : handleClick('user')
+  }, [postClick])
+
   const handleClick = (category: string) => {
     if (category === 'post') {
       setPostClick(true)
       setUserClick(false)
+      sessionStorage.setItem('category', 'post')
     } else {
       setPostClick(false)
       setUserClick(true)
+      sessionStorage.setItem('category', 'user')
     }
   }
 
@@ -51,11 +59,18 @@ export default function SearchPageTemplate({ data }: dataType) {
             />
           </div>
         </div>
-        <div className="data-grid" onScroll={restoreScrollPosition}>
+
+        <div className="data-grid">
           {postClick ? (
-            <PostGrid data={post}></PostGrid>
-          ) : (
+            post.length ? (
+              <PostGrid data={post}></PostGrid>
+            ) : (
+              <NoResultPage></NoResultPage>
+            )
+          ) : user.length ? (
             <UserGrid data={user}></UserGrid>
+          ) : (
+            <NoResultPage></NoResultPage>
           )}
         </div>
       </div>
@@ -87,13 +102,14 @@ const CategoryButton = ({
   </button>
 )
 
+const NoResultPage = () => (
+  <div className="data-grid-undefined">
+    <Text textStyle="heading2-bold" color="primary-4">
+      검색 결과가 없습니다
+    </Text>
+  </div>
+)
+
 export const isUser = (target: UserSummary | Post): target is UserSummary => {
   return (target as UserSummary).fullName !== undefined
-}
-
-export const restoreScrollPosition = () => {
-  console.log(document.getElementsByClassName('data-grid'))
-  const position = document.getElementsByClassName('data-grid')[0].scrollTop
-  sessionStorage.setItem('post-scroll-position', position.toString())
-  console.log(position)
 }

--- a/src/components/templates/SearchPageTemplate/index.scss
+++ b/src/components/templates/SearchPageTemplate/index.scss
@@ -34,33 +34,16 @@
   width: 100%;
   height: 100%;
   margin-top: 5rem;
-  overflow-y: scroll;
   padding: 1rem;
 }
 
-.data-grid::-webkit-scrollbar {
-  width: 0.5rem;
+.data-grid-undefined {
+  @include centerAlign();
+
+  width: 100%;
   height: 100%;
-}
-
-.data-grid::-webkit-scrollbar-track {
-  background: black;
-  border-radius: 0.5rem;
-}
-
-.data-grid::-webkit-scrollbar-thumb {
-  width: 0.5rem;
-  height: 6rem;
-  border-radius: 0.5rem;
-  @include themed() {
-    background-color: t(bg-2);
-  }
-}
-
-.data-grid::-webkit-scrollbar-thumb:hover {
-  @include themed() {
-    background: t(gray-4);
-  }
+  margin-top: 5rem;
+  padding: 1rem;
 }
 
 .category-button-container {


### PR DESCRIPTION
## - 목적
관련 이슈: #174 

<br>

## - 주요 변경 사항
- 검색 결과가 없는 페이지 구현
- 새로고침 및 뒤로가기 등 카테고리 유지(sessionStorage 이용)

## 기타 사항 (선택)
- merge 하면서 conflict가 많았는데 혹시 또 있다면 말씀 부탁드립니다. 


**현재 스크롤 복원 부분은 history.scrollRestoration가 auto로 되어 있음을 확인했으며, 다른 곳에서 적용이 됨 또한 확인했습니다. 다만 게시글과 사용자 간에 스크롤을 달리 주는 것은 같은 div를 쓰고 있어 인식하는 스크롤 위치가 같아 값을 달리 줄 수 없었는데 이 부분은 다시 살펴보겠습니다. (현재 로직은 같은 div(스크롤 작동 범위)를 공유하면서 데이터, children만 달리 줌)
혹시 스크롤과 관련해 조언해주실 부분이 있다면 부탁드립니다.**

<현재 시도한 방법>
- window.scrollY
- onScroll 속성
- document.get~~~ .scrollTop

**현재 스크롤 위치 값을 구해 sessionStorage에 저장하는 것은 성공했으나 post와 user를 각각 나눠 주려고 해도 값이 같이 변하거나 하나만 변해도 다른 카테고리로 돌아가면 다시 초기화 됩니다.**

<br>

## - 스크린샷 (선택)
