### PR TITLE
🎉 로그인 안된 유저가 내정보 페이지 접근시 라우팅

### DIFF
--- a/src/lib/contexts/authProvider.tsx
+++ b/src/lib/contexts/authProvider.tsx
@@ -8,7 +8,7 @@ import { useCurrentUser } from '@/hooks/useCurrentUser'
 
 interface AuthProviderProps {}
 
-const authNeededPages = [APP_PATH.postNew()]
+const authNeededPages = [APP_PATH.postNew(), APP_PATH.editProfile()]
 const authProhibitedPages = [APP_PATH.login(), APP_PATH.register()]
 
 export default function AuthProvider({


### PR DESCRIPTION
## - 목적
관련 이슈: #212 
-

<br>

## - 주요 변경 사항

- 로그인 안된 유저가 내정보 페이지 접근시 로그인 페이지로 이동하게 했습니다.

## 기타 사항 (선택)

-

<br>

## - 스크린샷 (선택)
