### PR TITLE
Post 카드 레이아웃 조정 및 title 데이터 파싱 처리

### DIFF
--- a/src/app/api/posts/author/route.ts
+++ b/src/app/api/posts/author/route.ts
@@ -13,9 +13,26 @@ export async function GET(req: NextRequest) {
       `/posts/author/${authorId}?offset=${offset}&limit=${limit}`,
     )
 
-    return NextResponse.json(
-      data.filter((post: Post) => post.channel._id === Environment.channelId()),
+    const targetPosts = data.filter(
+      (post: Post) => post.channel._id === Environment.channelId(),
     )
+    const parsedPosts = targetPosts.map((post: Post) => {
+      const parsedArticle = JSON.parse(post.title)
+      if (parsedArticle) {
+        return {
+          ...post,
+          title: parsedArticle.title,
+          description: parsedArticle.description,
+          mapping_ID: parsedArticle.mapping_ID,
+        }
+      } else {
+        return {
+          ...post,
+          description: '',
+        }
+      }
+    })
+    return NextResponse.json(parsedPosts)
   } catch (error: any) {
     return NextResponse.json(
       { error: error.response.data.message },

--- a/src/app/api/search/all/[keyword]/route.ts
+++ b/src/app/api/search/all/[keyword]/route.ts
@@ -1,5 +1,7 @@
 import { NextRequest } from 'next/server'
 import { Environment } from '@/config/environments'
+import Post from '@/types/post'
+import { UserSummary } from '@/types/user'
 
 async function fetchSearchData(keyword: string) {
   const decodeKeyword = decodeURI(keyword)
@@ -29,18 +31,38 @@ export async function GET(req: NextRequest) {
 
   try {
     const data = await fetchSearchData(keyword)
-    return new Response(
-      JSON.stringify(
-        data.filter(
-          ({ channel }: { channel: string }) =>
-            channel === Environment.channelId(),
-        ),
-      ),
-      { status: 200 },
+    const filteredData = data.filter(
+      ({ channel }: { channel: string }) =>
+        !channel || channel === Environment.channelId(),
     )
+    const parsedData = filteredData.map((data: UserSummary | Post) => {
+      if (!isUser(data)) {
+        const parsedArticle = JSON.parse(data.title)
+        if (parsedArticle) {
+          return {
+            ...data,
+            title: parsedArticle.title,
+            description: parsedArticle.description,
+            mapping_ID: parsedArticle.mapping_ID,
+          }
+        } else {
+          return {
+            ...data,
+            description: '',
+          }
+        }
+      }
+      return data
+    })
+    return new Response(JSON.stringify(parsedData), { status: 200 })
   } catch (error: any) {
+    console.error(error)
     return new Response(JSON.stringify({ error: error.message }), {
       status: Number(JSON.stringify({ error: error.status })),
     })
   }
+}
+
+const isUser = (target: UserSummary | Post): target is UserSummary => {
+  return (target as UserSummary).fullName !== undefined
 }

--- a/src/components/organisms/CardPostItem/CardPostItem.tsx
+++ b/src/components/organisms/CardPostItem/CardPostItem.tsx
@@ -38,7 +38,7 @@ export default function CardPostItem({
                 <Avatar
                   text={author.fullName}
                   size={1.25}
-                  src={image}
+                  src={author.image}
                   style={{
                     alignItems: 'flex-start',
                   }}

--- a/src/components/organisms/CardPostItem/CardPostItem.tsx
+++ b/src/components/organisms/CardPostItem/CardPostItem.tsx
@@ -35,34 +35,42 @@ export default function CardPostItem({
           <div className="content-container">
             <div className="content-container__header">
               <Link href={APP_PATH.userProfile(author._id)}>
-                <Avatar text={author.fullName} size={1.25} src={image} />
+                <Avatar
+                  text={author.fullName}
+                  size={1.25}
+                  src={image}
+                  style={{
+                    alignItems: 'flex-start',
+                  }}
+                />
               </Link>
               {isShowOptions && (
                 <PostOptionsDropdown postId={_id} setIsDeleted={setIsDeleted} />
               )}
             </div>
-            <Link href={`/post/${_id}`}>
+            <Link
+              href={APP_PATH.postDetail(_id)}
+              className="content-container__article-container"
+            >
               <Text textStyle="body1-bold">{title}</Text>
-            </Link>
-            {image ? (
-              <div className="content-container__image-container">
-                <Image src={image} alt="첨부 이미지" fill />
-              </div>
-            ) : (
-              <Link href={APP_PATH.userProfile(_id)}>
+              {image ? (
+                <div className="content-container__image-container">
+                  <Image src={image} alt="첨부 이미지" fill />
+                </div>
+              ) : (
                 <Text
                   textStyle="body2"
                   style={{
                     display: '-webkit-box',
-                    WebkitLineClamp: 8,
+                    WebkitLineClamp: 7,
                     WebkitBoxOrient: 'vertical',
                     overflow: 'hidden',
                   }}
                 >
                   {htmlTagParser(description)}
                 </Text>
-              </Link>
-            )}
+              )}
+            </Link>
             <LikeDislikeCount
               like={likes.length ?? 0}
               dislike={disLikes?.length ?? 0}

--- a/src/components/organisms/CardPostItem/index.scss
+++ b/src/components/organisms/CardPostItem/index.scss
@@ -7,14 +7,15 @@ $articleHeight: 9rem;
   width: 100%;
   min-height: 100%;
   position: relative;
-  &__title {
-    margin-bottom: 1rem;
+  &__header {
     overflow: hidden;
     text-overflow: ellipsis;
+    display: flex;
+    justify-content: space-between;
   }
   &__image-container {
     width: 100%;
-    min-height: $articleHeight;
+    height: $articleHeight;
     position: relative;
     img {
       object-fit: cover;
@@ -23,5 +24,8 @@ $articleHeight: 9rem;
   }
   &__article-container {
     min-height: $articleHeight;
+    display: flex;
+    flex-direction: column;
+    gap: 0.7rem;
   }
 }


### PR DESCRIPTION
## - 목적
관련 이슈: #160 
- CardPostItem 에서 클릭 영역 조정
- 검색 결과 및 유저 프로필에서 쓰이는 CardPostItem의 title 데이터가 파싱되지 않는 문제 해결

<br>

## - 주요 변경 사항

- 게시글 카드 클릭 영역 구분
- 아바타 프로필 이미지에 게시글 이미지 들어가는 문제 해결

<br>

- 기존에 검색 결과 페이지, 유저 프로필 페이지에서 title 데이터가 파싱되지 않아 json 데이터가 그대로 제목에 노출되는 문제 해결
- 검색 결과 반환 및 유저 게시글 불러오는 api에서 title 데이터를 title, description으로 나누도록 수정
- api 보면서 발견한 건데, 사용자 검색이 안 되는 문제가 channel을 필터링하면서 사용자 검색 결과가 같이 필터링이 되더라구요. 발견한 김에 함께 수정해두었습니다! @Lim-JiSeon 

## 기타 사항 (선택)

-

<br>

## - 스크린샷 (선택)
