### PR TITLE
🐛 글 작성 시 바로 홈 화면에 반영되게 설정

### DIFF
--- a/src/app/(root)/(routes)/(home)/page.tsx
+++ b/src/app/(root)/(routes)/(home)/page.tsx
@@ -5,11 +5,13 @@ import { useRouter } from 'next/navigation'
 import CirclePlusButton from '@/components/atoms/CirclePlusButton'
 import CardGridTemplate from '@/components/templates/CardGridTemplate'
 import APP_PATH from '@/config/paths'
+import { useCurrentUser } from '@/hooks/useCurrentUser'
 import { useInfiniteScroll } from '@/hooks/useInfiniteScroll'
 import useGetAllPosts from '@/queries/channel'
 
 export default function Home() {
-  const { data, fetchNextPage, hasNextPage } = useGetAllPosts()
+  const { currentUser } = useCurrentUser()
+  const { data, fetchNextPage, hasNextPage } = useGetAllPosts(currentUser)
 
   const { observerElem } = useInfiniteScroll({ fetchNextPage, hasNextPage })
   const router = useRouter()

--- a/src/app/(root)/(routes)/(home)/page.tsx
+++ b/src/app/(root)/(routes)/(home)/page.tsx
@@ -1,48 +1,15 @@
 'use client'
 
-import React, { useEffect, useState } from 'react'
+import React from 'react'
 import { useRouter } from 'next/navigation'
 import CirclePlusButton from '@/components/atoms/CirclePlusButton'
-import { notify } from '@/components/atoms/Toast'
 import CardGridTemplate from '@/components/templates/CardGridTemplate'
 import APP_PATH from '@/config/paths'
 import { useInfiniteScroll } from '@/hooks/useInfiniteScroll'
 import useGetAllPosts from '@/queries/channel'
-import { getPostDetail } from '@/services/post'
-import Post from '@/types/post'
 
 export default function Home() {
   const { data, fetchNextPage, hasNextPage } = useGetAllPosts()
-  const [posts, setPosts] = useState<Post[]>([])
-
-  useEffect(() => {
-    const fetchDisLikePost = async (postId: string) => {
-      try {
-        const data = await getPostDetail(postId)
-        return data.disLikePost
-      } catch (e) {
-        notify('error', '서버호출 시 문제가 발생했습니다.')
-      }
-    }
-
-    const loadInitDisLikePosts = async (posts: Post[]) => {
-      const mappingIdList = posts?.map((value) => value._id)
-
-      const postAllRes = await Promise.all(
-        mappingIdList?.map(async (id) => await fetchDisLikePost(id)),
-      )
-      const updatedPosts = posts.map((post, i) => {
-        return {
-          ...post,
-          disLikes: postAllRes[i]?.likes,
-        }
-      })
-
-      setPosts(updatedPosts)
-    }
-
-    loadInitDisLikePosts(data?.pages.flat() as Post[])
-  }, [data])
 
   const { observerElem } = useInfiniteScroll({ fetchNextPage, hasNextPage })
   const router = useRouter()
@@ -50,7 +17,7 @@ export default function Home() {
   return (
     <>
       <CardGridTemplate
-        postDatas={posts}
+        postDatas={data?.pages.flat() ?? []}
         ref={observerElem}
         isShowOptions={false}
       />

--- a/src/app/api/posts/author/route.ts
+++ b/src/app/api/posts/author/route.ts
@@ -1,7 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { Environment } from '@/config/environments'
 import { apiServer } from '@/lib/axiosSever'
-import Post from '@/types/post'
 
 export async function GET(req: NextRequest) {
   const authorId = req.nextUrl.searchParams.get('authorId') ?? 'undefined'
@@ -13,26 +11,7 @@ export async function GET(req: NextRequest) {
       `/posts/author/${authorId}?offset=${offset}&limit=${limit}`,
     )
 
-    //기존 채널의 포스트
-    const baseChannelPosts = data.filter(
-      (post: Post) => post.channel._id === Environment.channelId(),
-    )
-    //싫어요 채널의 포스트
-    const disLikeChannelPosts = data.filter(
-      (post: Post) => post.channel._id === Environment.dislikeChannelID(),
-    )
-
-    //기존 채널의 포스트와 싫어요 채널의 포스트 연결된 포스트
-    const updatedPosts = baseChannelPosts.map((post: Post) => {
-      return {
-        ...post,
-        disLikes: disLikeChannelPosts.filter(
-          (disLikeChannelPost: Post) =>
-            disLikeChannelPost._id === post.mapping_ID,
-        )[0].likes,
-      }
-    })
-    return NextResponse.json(updatedPosts)
+    return NextResponse.json(data)
   } catch (error: any) {
     return NextResponse.json(
       { error: error.response.data.message },

--- a/src/app/api/posts/author/route.ts
+++ b/src/app/api/posts/author/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
+import { Environment } from '@/config/environments'
 import { apiServer } from '@/lib/axiosSever'
 import type Post from "@/types/post"
 

--- a/src/app/api/posts/author/route.ts
+++ b/src/app/api/posts/author/route.ts
@@ -10,8 +10,9 @@ export async function GET(req: NextRequest) {
     const { data } = await apiServer.get(
       `/posts/author/${authorId}?offset=${offset}&limit=${limit}`,
     )
-
-    return NextResponse.json(data)
+    return NextResponse.json(
+      data.filter((post: Post) => post.channel._id === Environment.channelId()),
+    )
   } catch (error: any) {
     return NextResponse.json(
       { error: error.response.data.message },

--- a/src/app/api/posts/author/route.ts
+++ b/src/app/api/posts/author/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { apiServer } from '@/lib/axiosSever'
+import type Post from "@/types/post"
 
 export async function GET(req: NextRequest) {
   const authorId = req.nextUrl.searchParams.get('authorId') ?? 'undefined'

--- a/src/app/api/posts/author/route.ts
+++ b/src/app/api/posts/author/route.ts
@@ -13,9 +13,26 @@ export async function GET(req: NextRequest) {
       `/posts/author/${authorId}?offset=${offset}&limit=${limit}`,
     )
 
-    return NextResponse.json(
-      data.filter((post: Post) => post.channel._id === Environment.channelId()),
+    //기존 채널의 포스트
+    const baseChannelPosts = data.filter(
+      (post: Post) => post.channel._id === Environment.channelId(),
     )
+    //싫어요 채널의 포스트
+    const disLikeChannelPosts = data.filter(
+      (post: Post) => post.channel._id === Environment.dislikeChannelID(),
+    )
+
+    //기존 채널의 포스트와 싫어요 채널의 포스트 연결된 포스트
+    const updatedPosts = baseChannelPosts.map((post: Post) => {
+      return {
+        ...post,
+        disLikes: disLikeChannelPosts.filter(
+          (disLikeChannelPost: Post) =>
+            disLikeChannelPost._id === post.mapping_ID,
+        )[0].likes,
+      }
+    })
+    return NextResponse.json(updatedPosts)
   } catch (error: any) {
     return NextResponse.json(
       { error: error.response.data.message },

--- a/src/app/api/posts/route.ts
+++ b/src/app/api/posts/route.ts
@@ -25,20 +25,31 @@ async function getAllPosts(id: string, offset: string, limit: string) {
 
 export async function GET(req: NextRequest) {
   const id = Environment.channelId()
+  const disLikeChannelId = Environment.dislikeChannelID()
   const { searchParams } = req.nextUrl
   const offset = searchParams.get('offset') as string
   const limit = searchParams.get('limit') as string
   try {
     const posts = await getAllPosts(id || '', offset, limit)
+    const disLikesPosts = await getAllPosts(
+      disLikeChannelId || '',
+      offset,
+      limit,
+    )
 
     const parsedPosts = posts.map((post: Post) => {
       const parsedArticle = JSON.parse(post.title)
+      const findDisLikesMappingPost =
+        disLikesPosts.filter(
+          (post: Post) => post._id === parsedArticle.mapping_ID,
+        )[0]?.likes || []
       if (parsedArticle) {
         return {
           ...post,
           title: parsedArticle.title,
           description: parsedArticle.description,
           mapping_ID: parsedArticle.mapping_ID,
+          disLikes: findDisLikesMappingPost,
         }
       } else {
         return {

--- a/src/components/templates/CardGridTemplate/CardGridTemplate.tsx
+++ b/src/components/templates/CardGridTemplate/CardGridTemplate.tsx
@@ -21,13 +21,22 @@ export default forwardRef(function CardGridTemplate(
     <div className="card-grid-container">
       {postDatas?.map(
         (
-          { _id, image, author, title, description, likes }: CardPostItemProps,
+          {
+            _id,
+            image,
+            author,
+            title,
+            description,
+            likes,
+            disLikes,
+          }: CardPostItemProps,
           index,
         ) => {
           return (
             <CardPostItem
               key={_id + index}
               _id={_id}
+              disLikes={disLikes}
               image={image}
               author={author}
               title={title}

--- a/src/components/templates/CardGridTemplate/CardGridTemplate.tsx
+++ b/src/components/templates/CardGridTemplate/CardGridTemplate.tsx
@@ -8,7 +8,7 @@ import Post from '@/types/post'
 import './index.scss'
 
 type CardGridTemplateProps = {
-  postDatas: Post[] | undefined
+  postDatas: Post[]
   isShowOptions?: boolean
 }
 export default forwardRef(function CardGridTemplate(

--- a/src/queries/channel/index.ts
+++ b/src/queries/channel/index.ts
@@ -1,10 +1,11 @@
 import { useInfiniteQuery } from '@tanstack/react-query'
 import { constants } from '@/config/constants'
 import { getAllPosts } from '@/services/channel'
+import User from '@/types/user'
 
-const useGetAllPosts = () => {
+const useGetAllPosts = (user?: User) => {
   return useInfiniteQuery({
-    queryKey: ['getAllPostsInfiniteQuery'],
+    queryKey: ['getAllPostsInfiniteQuery', user],
     queryFn: ({ pageParam = 0 }) =>
       getAllPosts({
         offset: pageParam,


### PR DESCRIPTION
## - 목적
관련 이슈: #219 

- 괜히 이상하게 코드를 짜서 혼란이 있었네요.. 먼저 사죄의 말씀..올림니다..
- 기존 코드 갈아엎고 특정 채널의 포스트 목록을 가져오는 api로 변경했습니다

<br>

## - 주요 변경 사항

- 좋아요,싫어요 변경 시 홈으로 가면 바로 해당 좋아요 싫어요가 반영이 됩니다 !
- 글을 작성하면 바로 홈에 반영이 되게 수정했습니다.
- 추가적으로 회원 정보 변경 시 홈으로 리다이렉트 -> 바로 바뀐 내용이 적용되도록 queryKey에 현재 유저를 추가했습니다

## 기타 사항 (선택)

- 만약 해당 경우에도 바로 반영이 안되면 멘션 달아주세요!!

<br>

## - 스크린샷 (선택)

![sweet-trade-website-Chrome-2023-09-23-11-20-55](https://github.com/prgrms-fe-devcourse/FEDC4_Price-PCC_DONGYOUNG/assets/59411107/b901cd0c-27ba-4374-a79a-16f810eb9809)
