### PR TITLE
🐛 팔로우 삭제 -> 신청 -> 삭제 에러 해결

### DIFF
--- a/src/hooks/useFollow.ts
+++ b/src/hooks/useFollow.ts
@@ -47,7 +47,6 @@ const useFollow = (userData: User<Follow | string> | undefined) => {
     if (isFollowing) {
       setFollowerCount((prev) => prev - 1)
       setIsFollowing(false)
-
       const followData = currentUser.following?.find(
         ({ user }) => user === userData._id,
       )

--- a/src/hooks/useFollow.ts
+++ b/src/hooks/useFollow.ts
@@ -47,16 +47,22 @@ const useFollow = (userData: User<Follow | string> | undefined) => {
     if (isFollowing) {
       setFollowerCount((prev) => prev - 1)
       setIsFollowing(false)
+
       const followData = currentUser.following?.find(
         ({ user }) => user === userData._id,
       )
-      setFollowId(() => followData?._id ?? '')
       await deleteFollow(followData?._id ?? followId)
+      setFollowId(() => followData?._id ?? '')
+      currentUser.following?.splice(
+        currentUser.following.findIndex(({ user }) => user === userData._id),
+        1,
+      )
     } else {
       setIsFollowing(true)
       setFollowerCount((prev) => prev + 1)
       const followData = await postFollow(userData._id)
       setFollowId(() => followData._id ?? '')
+      currentUser.following?.push(followData)
     }
   }
 


### PR DESCRIPTION
## - 목적
관련 이슈: #246 
- 팔로우 신청을 먼저하는 것부터 연달아 토글을 할 때는 문제가 없었는데, 삭제부터 할 때는 그 다음 삭제가 에러가 났던 문제

<br>

## - 주요 변경 사항

원인
: 삭제할 때 id를 currentUser에서 해당 팔로우 정보를 불러와서 찾은 id를 넘기는데, 신청할 때 currentUser의 팔로우 정보를 업데이트시켜주지 않아 이전 id값으로 delete요청을 보내고 있었습니다.. 이전에 재희님이 작성하신 코드를 제가 잘못 건드려서 발생했던 문제네요 😂

팔로우 신청을 하면 currentUser의 팔로우 정보를 업데이트 시켜주어 해결했습니다!


## 기타 사항 (선택)

-

<br>

## - 스크린샷 (선택)
