### PR TITLE
🎉 검색 페이지 유저프로필 이동 에러 처리 및 일부 스타일 조정

### DIFF
--- a/src/components/organisms/CardUserItem/CardUserItem.tsx
+++ b/src/components/organisms/CardUserItem/CardUserItem.tsx
@@ -32,7 +32,17 @@ export default function CardUserItem({
             alt="profile-image"
             style={{ borderRadius: '50%' }}
           />
-          <Text textStyle="heading1-bold">{fullName}</Text>
+          <Text
+            textStyle="heading1-bold"
+            style={{
+              display: '-webkit-box',
+              WebkitLineClamp: 2,
+              WebkitBoxOrient: 'vertical',
+              overflow: 'hidden',
+            }}
+          >
+            {fullName}
+          </Text>
           <div className="follow-container">
             <MultiText title="팔로워" count={followers}></MultiText>
             <MultiText title="팔로잉" count={following}></MultiText>

--- a/src/components/organisms/CardUserItem/index.scss
+++ b/src/components/organisms/CardUserItem/index.scss
@@ -8,6 +8,7 @@
   @include centerAlign();
   flex-direction: column;
   gap: 1.5rem;
+  text-align: center;
 }
 
 .follow-container {

--- a/src/components/organisms/Header/index.scss
+++ b/src/components/organisms/Header/index.scss
@@ -47,6 +47,7 @@
   }
 
   .avatar__container {
+    width: 12rem;
     padding: 0;
   }
 

--- a/src/components/organisms/PostGrid/PostGrid.tsx
+++ b/src/components/organisms/PostGrid/PostGrid.tsx
@@ -1,30 +1,22 @@
 'use client'
 
-import { CardPostItem } from '@/components/organisms/CardPostItem'
-import { CardPostItemProps } from '@/components/organisms/CardPostItem/CardPostItem'
-import Post from '@/types/post'
+import SearchPostItem from '@/components/organisms/SearchPostItem'
+import { SearchPostItemProps } from '@/components/organisms/SearchPostItem/SearchPostItem'
+import PostSummary from '@/types/post'
 import './index.scss'
 
 type PropsType = {
-  data: Post[] | undefined
+  data: PostSummary[] | undefined
 }
 export default function PostGrid({ data }: PropsType) {
   return (
     <div className="card-grid-container">
       {data?.map(
-        ({
-          _id,
-          image,
-          author,
-          title,
-          description,
-          likes,
-        }: CardPostItemProps) => (
-          <CardPostItem
+        ({ _id, image, title, description, likes }: SearchPostItemProps) => (
+          <SearchPostItem
             key={_id}
             _id={_id}
             image={image}
-            author={author}
             title={title}
             likes={likes}
             description={description}

--- a/src/components/organisms/SearchPostItem/SearchPostItem.tsx
+++ b/src/components/organisms/SearchPostItem/SearchPostItem.tsx
@@ -1,0 +1,60 @@
+import Image from 'next/image'
+import Link from 'next/link'
+import { Card } from '@/components/atoms/Card'
+import { Text } from '@/components/atoms/Text'
+import { LikeDislikeCount } from '@/components/molcules/LikeDislikeCount'
+import APP_PATH from '@/config/paths'
+import Post from '@/types/post'
+import htmlTagParser from '@/utils/htmlTagParser'
+import './index.scss'
+
+export type SearchPostItemProps = Pick<
+  Post,
+  '_id' | 'image' | 'title' | 'description' | 'disLikes' | 'likes'
+>
+export default function SearchPostItem({
+  _id,
+  image,
+  title,
+  description,
+  disLikes,
+  likes,
+}: SearchPostItemProps) {
+  return (
+    <>
+      <Card>
+        <div className="content-container">
+          <Link
+            href={APP_PATH.postDetail(_id)}
+            className="content-container__article-container"
+          >
+            <Text className="post-title" textStyle="body1-bold">
+              {title}
+            </Text>
+            {image ? (
+              <div className="content-container__image-container">
+                <Image src={image} alt="첨부 이미지" fill />
+              </div>
+            ) : (
+              <Text
+                textStyle="body2"
+                style={{
+                  display: '-webkit-box',
+                  WebkitLineClamp: 7,
+                  WebkitBoxOrient: 'vertical',
+                  overflow: 'hidden',
+                }}
+              >
+                {htmlTagParser(description)}
+              </Text>
+            )}
+          </Link>
+          <LikeDislikeCount
+            like={likes.length ?? 0}
+            dislike={disLikes?.length ?? 0}
+          />
+        </div>
+      </Card>
+    </>
+  )
+}

--- a/src/components/organisms/SearchPostItem/index.scss
+++ b/src/components/organisms/SearchPostItem/index.scss
@@ -1,0 +1,28 @@
+$articleHeight: 9rem;
+.content-container {
+  display: flex;
+  flex-direction: column;
+  gap: 1.12rem;
+  width: 100%;
+  min-height: 100%;
+  position: relative;
+  &__image-container {
+    width: 100%;
+    height: $articleHeight;
+    position: relative;
+    img {
+      object-fit: cover;
+      border-radius: 1.2rem;
+    }
+  }
+  &__article-container {
+    min-height: $articleHeight;
+    display: flex;
+    flex-direction: column;
+    gap: 0.7rem;
+  }
+
+  .post-title {
+    padding-bottom: 1rem;
+  }
+}

--- a/src/components/organisms/SearchPostItem/index.ts
+++ b/src/components/organisms/SearchPostItem/index.ts
@@ -1,0 +1,1 @@
+export { default } from './SearchPostItem'


### PR DESCRIPTION
## - 목적
관련 이슈: #222 

<br>

## - 주요 변경 사항
- 검색 페이지에서 게시물에서는 작성자 프로필을 삭제했습니다. (api res로 오는 값에 작성자 프로필을 채울 데이터가 없기 때문)
- (결과적으로)전용 검색 페이지 게시물 카드를 만들었습니다.
- 검색 페이지의 유저 프로필 카드에서 유저 닉네임이 길어질 경우 ... 으로 처리했습니다.
- (마찬가지로) 헤더부분에서도 아바타의 길이를 제한하고 ... 처리를 추가했습니다. 

## 기타 사항 (선택)
- 새로운 검색 페이지 전용 포스트 카드를 만든 이유는 다음과 같습니다.
- api의 res로 author를 id 값인 string만 넘겨주는데 이럴 경우 author의 fullName, image 를 알 수 없습니다. 
- 이를 해결하기 위해서는 받은 id를 이용해서 User 객체를 받을 수 있는 api를 추가로 호출해야 합니다. 
- 이에 비효율적이라 판단 결국 검색 페이지에서 게시물에 한해서만 제거하게 되었습니다.
- 민희님께서 게시물 상세 페이지에서 작성자 프로필 페이지로 이동할 수 있는 링크를 추가해주면서 필수적으로 추가할 필요성이 낮아졌기 때문도 있습니다. (감사합니다 민희님!!)

<br>

## - 스크린샷 (선택)
- 검색 페이지에서 보이는 게시물 카드
<img width="332" alt="image" src="https://github.com/prgrms-fe-devcourse/FEDC4_Price-PCC_DONGYOUNG/assets/83554018/d838beb8-dd4a-4772-97ef-5c8004736834">

- 헤더 수정
<img width="1063" alt="image" src="https://github.com/prgrms-fe-devcourse/FEDC4_Price-PCC_DONGYOUNG/assets/83554018/44dc861c-2879-48ff-b6d9-4492b3123e97">

- 검색 페이지에서 보이는 유저 프로필 카드
<img width="1012" alt="image" src="https://github.com/prgrms-fe-devcourse/FEDC4_Price-PCC_DONGYOUNG/assets/83554018/62a13bdc-27e9-423d-b075-1dbb0329f3e5">
