### PR TITLE
🎉 계정 정보 변경 페이지 ui 변경

### DIFF
--- a/src/components/molcules/EditNamesForm/EditNamesform.tsx
+++ b/src/components/molcules/EditNamesForm/EditNamesform.tsx
@@ -18,12 +18,7 @@ const EditNamesform = ({ fullName }: NameProps) => {
   const [currentName, setCurrentName] = useState('')
   const { editProfile } = useEditProfile()
 
-  const {
-    register,
-    handleSubmit,
-    setValue,
-    formState: { errors },
-  } = useForm<FormValues>({
+  const { register, handleSubmit, setValue } = useForm<FormValues>({
     defaultValues: {
       fullName: '',
       username: '',
@@ -33,17 +28,13 @@ const EditNamesform = ({ fullName }: NameProps) => {
   return (
     <form
       onSubmit={handleSubmit(async (data) => {
-        if (data.fullName.length < 1) {
-          notify('error', `${errors.fullName?.message}`)
-        } else {
-          try {
-            await editProfile(data)
-            notify('success', '닉네임이 수정되었습니다.')
-            setCurrentName(data.fullName)
-            setValue('fullName', '')
-          } catch (error) {
-            notify('error', '닉네임 수정에 실패했습니다.')
-          }
+        try {
+          await editProfile(data)
+          notify('success', '닉네임이 수정되었습니다.')
+          setCurrentName(data.fullName)
+          setValue('fullName', '')
+        } catch (error) {
+          notify('error', '닉네임 수정에 실패했습니다.')
         }
       })}
       style={{ display: 'flex', justifyContent: 'space-between' }}
@@ -51,7 +42,7 @@ const EditNamesform = ({ fullName }: NameProps) => {
       <Input
         {...(register &&
           register('fullName', {
-            required: '변경 할 닉네임을 작성해주세요.',
+            required: true,
           }))}
         placeholder={currentName.length > 0 ? currentName : fullName}
         variant="clear"

--- a/src/components/molcules/EditNamesForm/EditNamesform.tsx
+++ b/src/components/molcules/EditNamesForm/EditNamesform.tsx
@@ -1,9 +1,8 @@
+import { useState } from 'react'
 import { useForm } from 'react-hook-form'
-import { useRouter } from 'next/navigation'
 import { Button } from '@/components/atoms/Button'
 import Input from '@/components/atoms/Input'
 import { notify } from '@/components/atoms/Toast'
-import APP_PATH from '@/config/paths'
 import { useEditProfile } from '@/hooks/useEditUserProfile'
 
 interface FormValues {
@@ -16,12 +15,13 @@ export type NameProps = {
 }
 
 const EditNamesform = ({ fullName }: NameProps) => {
-  const router = useRouter()
+  const [currentName, setCurrentName] = useState('')
   const { editProfile } = useEditProfile()
 
   const {
     register,
     handleSubmit,
+    setValue,
     formState: { errors },
   } = useForm<FormValues>({
     defaultValues: {
@@ -39,7 +39,8 @@ const EditNamesform = ({ fullName }: NameProps) => {
           try {
             await editProfile(data)
             notify('success', '닉네임이 수정되었습니다.')
-            router.push(APP_PATH.home())
+            setCurrentName(data.fullName)
+            setValue('fullName', '')
           } catch (error) {
             notify('error', '닉네임 수정에 실패했습니다.')
           }
@@ -52,7 +53,7 @@ const EditNamesform = ({ fullName }: NameProps) => {
           register('fullName', {
             required: '변경 할 닉네임을 작성해주세요.',
           }))}
-        placeholder={fullName}
+        placeholder={currentName.length > 0 ? currentName : fullName}
         variant="clear"
         outline="underbar"
         style={{

--- a/src/components/molcules/EditNamesForm/EditNamesform.tsx
+++ b/src/components/molcules/EditNamesForm/EditNamesform.tsx
@@ -19,7 +19,11 @@ const EditNamesform = ({ fullName }: NameProps) => {
   const router = useRouter()
   const { editProfile } = useEditProfile()
 
-  const { register, handleSubmit } = useForm<FormValues>({
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<FormValues>({
     defaultValues: {
       fullName: '',
       username: '',
@@ -29,33 +33,45 @@ const EditNamesform = ({ fullName }: NameProps) => {
   return (
     <form
       onSubmit={handleSubmit(async (data) => {
-        try {
-          await editProfile(data)
-          notify('success', '정보가 수정되었습니다.')
-          router.push(APP_PATH.home())
-        } catch (error) {
-          notify('error', '정보 수정에 실패했습니다.')
+        if (data.fullName.length < 1) {
+          notify('error', `${errors.fullName?.message}`)
+        } else {
+          try {
+            await editProfile(data)
+            notify('success', '닉네임이 수정되었습니다.')
+            router.push(APP_PATH.home())
+          } catch (error) {
+            notify('error', '닉네임 수정에 실패했습니다.')
+          }
         }
       })}
+      style={{ display: 'flex', justifyContent: 'space-between' }}
     >
       <Input
         {...(register &&
           register('fullName', {
-            required: true,
+            required: '변경 할 닉네임을 작성해주세요.',
           }))}
         placeholder={fullName}
         variant="clear"
         outline="underbar"
-        style={{ boxSizing: 'border-box', marginBottom: '4rem' }}
+        style={{
+          width: 'auto',
+          boxSizing: 'border-box',
+          marginBottom: '4rem',
+          padding: '10px, 5px',
+          fontSize: '1.1rem',
+        }}
       />
       <Button
         isShadowed={true}
-        text="수정 완료"
-        height={3.6875}
+        text="닉네임 변경"
+        width={14.06}
+        height={2.06}
         variant="default"
-        rounded="rounded-lg"
+        rounded="rounded-md"
         type="submit"
-        style={{ width: '100%' }}
+        style={{ fontSize: '1rem' }}
       />
     </form>
   )

--- a/src/components/molcules/EditProfileImageForm/EditProfileImageForm.tsx
+++ b/src/components/molcules/EditProfileImageForm/EditProfileImageForm.tsx
@@ -1,6 +1,8 @@
 import { useRef, useState, ChangeEvent } from 'react'
+import { FiSettings } from 'react-icons/fi'
 import Image from 'next/image'
 import { Button } from '@/components/atoms/Button'
+import { notify } from '@/components/atoms/Toast'
 import { SetEditProfileComponent } from '@/components/organisms/EditProfile/EditProfile'
 import Assets from '@/config/assets'
 import { useEditProfileImage } from '@/hooks/useEditUserImage'
@@ -41,22 +43,35 @@ const EditProfileImageForm = ({
         ref={selectProfileFile}
         onChange={handleFileChange}
       />
-      <Image
+      <div
+        className="edit-profile-image-form__image-file"
         onClick={() => selectProfileFile?.current?.click()}
-        src={thumnail}
-        width={180}
-        height={180}
-        style={{ borderRadius: '50%' }}
-        alt="profile-image"
-      />
+      >
+        <Image
+          src={thumnail}
+          width={180}
+          height={180}
+          style={{ borderRadius: '50%' }}
+          alt="profile-image"
+        />
+        <FiSettings
+          size={30}
+          color="gray-5"
+          style={{ position: 'absolute', right: '0px', bottom: '0px' }}
+        />
+      </div>
       <div className="edit-profile-image-form__buttons">
         <Button
           onClick={async () => {
-            await editProfileImage({
-              isCover: false,
-              image: profile!,
-            })
-            setProfile(null)
+            if (!profile) {
+              notify('error', '이미지 파일을 선택 해주세요.')
+            } else {
+              await editProfileImage({
+                isCover: false,
+                image: profile!,
+              })
+              setProfile(null)
+            }
           }}
           isShadowed={true}
           text="프로필 이미지 변경"

--- a/src/components/molcules/EditProfileImageForm/index.scss
+++ b/src/components/molcules/EditProfileImageForm/index.scss
@@ -2,6 +2,10 @@
   display: flex;
   margin-bottom: 7rem;
 
+  &__image-file {
+    position: relative;
+  }
+
   &__buttons {
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
## - 목적
관련 이슈: #237 
-

<br>

## - 주요 변경 사항

- 프로필 이미지 파일 선택 input에 톱니바퀴 아이콘을 추가하여 좀 더 파일을 선택하는 input임을 알기 쉽게 수정 되었습니다.
- 프로필 이미지를 선택하지 않고 프로필 이미지 변경 버튼 클릭 시 파일을 선택해달라고 알림이 뜨게 수정 되었습니다.
- 닉네임 변경 버튼의 크기와 위치가 닉네임만 변경 한다는 것을 알 수 있게 수정 되었습니다.

## 기타 사항 (선택)

- 

<br>

## - 스크린샷 (선택)
![image](https://github.com/prgrms-fe-devcourse/FEDC4_Price-PCC_DONGYOUNG/assets/66124037/b4962a94-1747-4a87-ad1b-b99d71e7b21e)

