### PR TITLE
🎉  팔로우 리스트 모달 api 호출 지연, 로딩 컴포넌트 추가

### DIFF
--- a/src/components/atoms/Loading/Loading.tsx
+++ b/src/components/atoms/Loading/Loading.tsx
@@ -1,0 +1,19 @@
+import './index.scss'
+
+/**
+ * 로딩 컴포넌트 (동그라미 회전)
+ * @param size number rem 단위
+ */
+export default function Loading({ size }: { size: number }) {
+  return (
+    <div className="loader-container">
+      <span
+        className="loader-container__loader"
+        style={{
+          width: `${size}rem`,
+          height: `${size}rem`,
+        }}
+      ></span>
+    </div>
+  )
+}

--- a/src/components/atoms/Loading/index.scss
+++ b/src/components/atoms/Loading/index.scss
@@ -1,0 +1,52 @@
+@import '@/styles/variables.scss';
+
+.loader-container {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  &__loader {
+    width: 5rem;
+    height: 5rem;
+    border-radius: 50%;
+    position: relative;
+    animation: rotate 1s linear infinite;
+  }
+  &__loader::before {
+    content: '';
+    box-sizing: border-box;
+    position: absolute;
+    inset: 0px;
+    border-radius: 50%;
+    border: 5px solid;
+    @include themed() {
+      border-color: t(gray-3);
+    }
+    animation: prixClipFix 2s linear infinite;
+  }
+}
+
+@keyframes rotate {
+  100% {
+    transform: rotate(360deg);
+  }
+}
+
+@keyframes prixClipFix {
+  0% {
+    clip-path: polygon(50% 50%, 0 0, 0 0, 0 0, 0 0, 0 0);
+  }
+  25% {
+    clip-path: polygon(50% 50%, 0 0, 100% 0, 100% 0, 100% 0, 100% 0);
+  }
+  50% {
+    clip-path: polygon(50% 50%, 0 0, 100% 0, 100% 100%, 100% 100%, 100% 100%);
+  }
+  75% {
+    clip-path: polygon(50% 50%, 0 0, 100% 0, 100% 100%, 0 100%, 0 100%);
+  }
+  100% {
+    clip-path: polygon(50% 50%, 0 0, 100% 0, 100% 100%, 0 100%, 0 0);
+  }
+}

--- a/src/components/atoms/Loading/index.stories.ts
+++ b/src/components/atoms/Loading/index.stories.ts
@@ -1,0 +1,21 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import Loading from '.'
+
+const meta = {
+  title: 'Componentes/Loading',
+  component: Loading,
+} satisfies Meta<typeof Loading>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+  args: {
+    size: 5,
+  },
+  argTypes: {
+    size: {
+      type: 'number',
+    },
+  },
+}

--- a/src/components/atoms/Loading/index.ts
+++ b/src/components/atoms/Loading/index.ts
@@ -1,0 +1,3 @@
+import Loading from './Loading'
+
+export default Loading

--- a/src/components/molcules/FollowListItem/FollowListItem.tsx
+++ b/src/components/molcules/FollowListItem/FollowListItem.tsx
@@ -14,12 +14,14 @@ export default function FollowListItem({ targetUserId }: FollowListItemProps) {
     useFollow(data)
   return (
     <li className="follow-list-item">
-      <Avatar
-        src={data?.image}
-        text={data?.fullName}
-        subText={`${followerCount} Followers`}
-        size={4}
-      />
+      <div className="follow-list-item__avatar">
+        <Avatar
+          src={data?.image}
+          text={data?.fullName}
+          subText={`${followerCount} Followers`}
+          size={4}
+        />
+      </div>
       <FollowToggleButton
         size="small"
         isFollowing={isFollowing}

--- a/src/components/molcules/FollowListItem/index.scss
+++ b/src/components/molcules/FollowListItem/index.scss
@@ -4,4 +4,7 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
+  &__avatar {
+    width: 75%;
+  }
 }

--- a/src/components/organisms/UserDetailCard/section/Follows.tsx
+++ b/src/components/organisms/UserDetailCard/section/Follows.tsx
@@ -1,14 +1,15 @@
 'use client'
 
-import React, { useState } from 'react'
+import React, { Suspense, lazy, useState } from 'react'
 import FollowToggleButton from '@/components/atoms/FollowToggleButton'
+import Loading from '@/components/atoms/Loading'
 import { Text } from '@/components/atoms/Text'
 import ModalProvider from '@/components/molcules/ModalLayout'
-import FollowList from '@/components/organisms/FollowList'
 import useFollow from '@/hooks/useFollow'
 import useModal from '@/hooks/useModal'
 import User from '@/types/user'
 
+const LazyFollowList = lazy(() => import('@/components/organisms/FollowList'))
 export default function Follows({ userData }: { userData: User }) {
   const {
     unavailable,
@@ -59,7 +60,12 @@ export default function Follows({ userData }: { userData: User }) {
         handleModalClose={handleModalClose}
       >
         {isModalOpen && (
-          <FollowList isFollowerList={isFollowerModal} userData={userData} />
+          <Suspense fallback={<Loading size={5} />}>
+            <LazyFollowList
+              isFollowerList={isFollowerModal}
+              userData={userData}
+            />
+          </Suspense>
         )}
       </ModalProvider>
     </>

--- a/src/components/organisms/UserDetailCard/section/Follows.tsx
+++ b/src/components/organisms/UserDetailCard/section/Follows.tsx
@@ -58,7 +58,9 @@ export default function Follows({ userData }: { userData: User }) {
         modalHeight={44}
         handleModalClose={handleModalClose}
       >
-        <FollowList isFollowerList={isFollowerModal} userData={userData} />
+        {isModalOpen && (
+          <FollowList isFollowerList={isFollowerModal} userData={userData} />
+        )}
       </ModalProvider>
     </>
   )

--- a/src/queries/comments/index.ts
+++ b/src/queries/comments/index.ts
@@ -4,6 +4,7 @@ import type Comment from '@/types/comment'
 
 const useGetComment = (postId: string, initComments?: Comment[]) => {
   return useQuery({
+    queryKey: ['getComment', postId],
     queryFn: async () => {
       const data = await getPostDetail(postId)
       return data


### PR DESCRIPTION
## - 목적
관련 이슈: #231 
-

<br>

## - 주요 변경 사항

- 모달 열었을 때, 닫았을 때 transition 효과를 주려면 초기 로딩 시 아예 렌더링이 되지 않게 막을 수는 없는 것 같습니다 (저의 지식과 능력의 범위 안에서는요.. 방법을 아시는 분 계시면 알려주세요..!)
- 그래서 차선책으로 모달 껍데기는 렌더링이 되게 하고, 그 안의 내용 (팔로우 리스트)은 모달을 열었을 때 조건부 렌더링되도록 처리했습니다.
- 따라서 유저 프로필 페이지로 이동하자마자 팔로우 정보를 위해 api 다다다 호출하는 건 이제 모달을 열었을 때 요청이 갑니다.

<br>

- 추가로 구조 상 팔로우 리스트는 api요청이 많기 때문에 렌더링 되기까지 로딩 컴포넌트가 뜨도록 Suspense와 LazyLoading을 사용했습니다.

## 기타 사항 (선택)

- query key 추가한 커밋은 작업하면서 경고?에러?가 뜨길래 추가해놨던 건데, 효중님 @khj0426 이 수정해주신 PR 확인했습니다! 충돌나면 제가 작성한 걸 지우면 될 것 같습니다.
- 추가로 팔로우 리스트에서 닉네임이 긴 아바타가 가로로 넘치는 문제를 수정했습니다.

<br>

## - 스크린샷 (선택)
