### PR TITLE
🐛 닉네임, 프로필 이미지 변경시 바로 적용

### DIFF
--- a/src/components/molcules/EditNamesForm/EditNamesform.tsx
+++ b/src/components/molcules/EditNamesForm/EditNamesform.tsx
@@ -1,9 +1,10 @@
-import { useState } from 'react'
 import { useForm } from 'react-hook-form'
 import { Button } from '@/components/atoms/Button'
 import Input from '@/components/atoms/Input'
 import { notify } from '@/components/atoms/Toast'
+import { useValidate } from '@/hooks/useCurrentUser'
 import { useEditProfile } from '@/hooks/useEditUserProfile'
+import useGetAllUsers from '@/queries/users'
 
 interface FormValues {
   fullName: string
@@ -15,7 +16,8 @@ export type NameProps = {
 }
 
 const EditNamesform = ({ fullName }: NameProps) => {
-  const [currentName, setCurrentName] = useState('')
+  const validate = useValidate()
+  const getAllUsers = useGetAllUsers()
   const { editProfile } = useEditProfile()
 
   const { register, handleSubmit, setValue } = useForm<FormValues>({
@@ -31,7 +33,8 @@ const EditNamesform = ({ fullName }: NameProps) => {
         try {
           await editProfile(data)
           notify('success', '닉네임이 수정되었습니다.')
-          setCurrentName(data.fullName)
+          validate.refetch()
+          getAllUsers.refetch()
           setValue('fullName', '')
         } catch (error) {
           notify('error', '닉네임 수정에 실패했습니다.')
@@ -44,7 +47,7 @@ const EditNamesform = ({ fullName }: NameProps) => {
           register('fullName', {
             required: true,
           }))}
-        placeholder={currentName.length > 0 ? currentName : fullName}
+        placeholder={fullName}
         variant="clear"
         outline="underbar"
         style={{

--- a/src/components/molcules/EditProfileImageForm/EditProfileImageForm.tsx
+++ b/src/components/molcules/EditProfileImageForm/EditProfileImageForm.tsx
@@ -5,7 +5,9 @@ import { Button } from '@/components/atoms/Button'
 import { notify } from '@/components/atoms/Toast'
 import { SetEditProfileComponent } from '@/components/organisms/EditProfile/EditProfile'
 import Assets from '@/config/assets'
+import { useValidate } from '@/hooks/useCurrentUser'
 import { useEditProfileImage } from '@/hooks/useEditUserImage'
+import useGetAllUsers from '@/queries/users'
 import './index.scss'
 
 type EditProfileImageFormProps = SetEditProfileComponent & {
@@ -16,6 +18,8 @@ const EditProfileImageForm = ({
   setPage,
   image,
 }: EditProfileImageFormProps) => {
+  const validate = useValidate()
+  const getAllUsers = useGetAllUsers()
   const { editProfileImage } = useEditProfileImage()
   const [profile, setProfile] = useState<File | null>(null)
   const selectProfileFile = useRef<HTMLInputElement | null>(null)
@@ -70,6 +74,8 @@ const EditProfileImageForm = ({
                 isCover: false,
                 image: profile!,
               })
+              validate.refetch()
+              getAllUsers.refetch()
               setProfile(null)
             }
           }}

--- a/src/hooks/useCurrentUser.ts
+++ b/src/hooks/useCurrentUser.ts
@@ -7,7 +7,7 @@ import { constants } from '@/config/constants'
 import { validateToken } from '@/services/auth'
 import User from '@/types/user'
 
-const useValidate = () => {
+export const useValidate = () => {
   const token = Cookies.get(constants.AUTH_TOKEN)
   return useQuery(
     ['validateToken', token],


### PR DESCRIPTION
## - 목적
관련 이슈: #236 
-

<br>

## - 주요 변경 사항

- 계정 정보 변경 페이지에서 닉네임, 프로필 이미지를 변경했을 때 계정 정보 변경 페이지, 헤더, 사이드바에 적용되지 않던 현상을 바로 적용되게 수정 하였습니다.

## 기타 사항 (선택)

- 

<br>

## - 스크린샷 (선택)
