### PR TITLE
:bug: 서버 쿠키 set 제거 (다크모드 client component에서 처리)

### DIFF
--- a/src/components/organisms/Header/Header.tsx
+++ b/src/components/organisms/Header/Header.tsx
@@ -1,4 +1,3 @@
-import { cookies } from 'next/headers'
 import Link from 'next/link'
 import DarkModeButton from '@/components/atoms/DarkModeButton'
 import NotificationButton from '@/components/atoms/NotificationButton'
@@ -6,31 +5,19 @@ import SearchBar from '@/components/atoms/SearchBar'
 import { Text } from '@/components/atoms/Text'
 import AvatarDropdown from '@/components/molcules/AvatarDropdown/AvatarDropdown'
 import APP_PATH from '@/config/paths'
+import { useDarkmodeCookie } from '@/hooks/useDarkmodeCookie'
 import { validateToken } from '@/services/auth'
 import './index.scss'
 
-async function updateCookie(key: string, value: string) {
-  const cookieStore = cookies()
-  cookieStore.set(key, value)
-}
-
 export default async function Header() {
-  const cookieStore = cookies()
   const data = validateToken()
 
   let systemDarkmode = false
   if (typeof window !== 'undefined') {
     systemDarkmode = window.matchMedia('(prefers-color-scheme: dark)').matches
   }
-  let darkMode = systemDarkmode
 
-  const cookieVal = cookieStore.get('pcc-darkmode')
-  if (cookieVal) {
-    darkMode = JSON.parse(cookieVal?.value!)
-  } else {
-    updateCookie('pcc-darkmode', JSON.stringify(systemDarkmode))
-    darkMode = systemDarkmode
-  }
+  const { darkMode } = useDarkmodeCookie(systemDarkmode)
 
   if (typeof window !== 'undefined') {
     if (darkMode) {

--- a/src/hooks/useDarkmodeCookie.ts
+++ b/src/hooks/useDarkmodeCookie.ts
@@ -1,0 +1,16 @@
+import { cookies } from 'next/headers'
+
+export function useDarkmodeCookie(intialValue: boolean) {
+  if (typeof window !== 'undefined') {
+    throw new Error('This hook should be used in server-side only')
+  }
+
+  const cookieStore = cookies()
+  let darkMode = intialValue
+  const cookieVal = cookieStore.get('pcc-darkmode')
+  if (cookieVal) {
+    darkMode = JSON.parse(cookieVal?.value!)
+  }
+
+  return { darkMode }
+}


### PR DESCRIPTION
## - 목적
관련 이슈: #256

<br>

## - 주요 변경 사항

- 서버에서 쿠키를 저장하는 부분을 제거했습니다.
- 서버에서 쿠키를 저장하려면 api router를 만들거나 13.4버전부터 실험적으로 도입된 Server Action이라는 걸 써야하는데, 그럴 필요 없이 그냥 쿠키에 저장하는 건 클라이언트 컴포넌트인 다크모드 버튼 컴포넌트 안에서 처리하기 때문에 그냥 삭제했습니다.
- 쿠키에 저장된 값을 가져오는 로직을 훅으로 분리해서 Header의 코드를 줄였습니다.


## 기타 사항 (선택)

-

<br>

## - 스크린샷 (선택)
