### PR TITLE
:sparkles: header 로딩 방식 수정

### DIFF
--- a/src/app/(root)/layout.tsx
+++ b/src/app/(root)/layout.tsx
@@ -14,7 +14,7 @@ export const metadata: Metadata = {
   description: 'judge your trades by their sweetness',
 }
 
-export default function RootLayout({
+export default async function RootLayout({
   children,
 }: {
   children: React.ReactNode
@@ -23,6 +23,7 @@ export default function RootLayout({
   const isDark = cookieStore.get('pcc-darkmode')?.value
   const THEME_CLASSNAME =
     isDark === 'true' ? 'pcc-theme--dark' : 'pcc-theme--light'
+
   return (
     <html lang="ko">
       <TanstackQueryContext>

--- a/src/app/api/login/route.ts
+++ b/src/app/api/login/route.ts
@@ -1,3 +1,4 @@
+import { revalidateTag } from 'next/cache'
 import { cookies } from 'next/headers'
 import { NextResponse } from 'next/server'
 import { constants } from '@/config/constants'
@@ -14,6 +15,8 @@ export async function POST(request: Request) {
       path: '/',
       maxAge: 60 * 60 * 24 * 30,
     })
+
+    revalidateTag('auth')
 
     return NextResponse.json(data)
   } catch (error: any) {

--- a/src/components/molcules/AvatarDropdown/AvatarDropdown.tsx
+++ b/src/components/molcules/AvatarDropdown/AvatarDropdown.tsx
@@ -4,12 +4,17 @@ import { useCallback, useState } from 'react'
 import Image from 'next/image'
 import Avatar from '@/components/atoms/Avatar'
 import Assets from '@/config/assets'
-import { useAuth } from '@/lib/contexts/authProvider'
+import User from '@/types/user'
 import ModalDropdownList from '../ModalDropdownList'
 import './index.scss'
 
-export default function AvatarDropdown({ darkmode }: { darkmode: boolean }) {
-  const { currentUser } = useAuth()
+export default function AvatarDropdown({
+  darkmode,
+  currentUser,
+}: {
+  darkmode: boolean
+  currentUser: User
+}) {
   const [dropdownClick, setDropdownClick] = useState(false)
   const handleDropdown = useCallback(() => {
     setDropdownClick((prevClick) => !prevClick)

--- a/src/components/organisms/Header/Header.tsx
+++ b/src/components/organisms/Header/Header.tsx
@@ -1,16 +1,39 @@
+import { cookies } from 'next/headers'
 import Link from 'next/link'
 import DarkModeButton from '@/components/atoms/DarkModeButton'
 import NotificationButton from '@/components/atoms/NotificationButton'
 import SearchBar from '@/components/atoms/SearchBar'
 import { Text } from '@/components/atoms/Text'
 import AvatarDropdown from '@/components/molcules/AvatarDropdown/AvatarDropdown'
+import { constants } from '@/config/constants'
+import { Environment } from '@/config/environments'
 import APP_PATH from '@/config/paths'
 import { useDarkmodeCookie } from '@/hooks/useDarkmodeCookie'
-import { validateToken } from '@/services/auth'
+import User from '@/types/user'
 import './index.scss'
 
+const getCurrentUser = async (): Promise<User | null | undefined> => {
+  const cookieStore = cookies()
+  const token = cookieStore.get(constants.AUTH_TOKEN)
+
+  try {
+    const res = await fetch(`${Environment.baseUrl()}/auth-user`, {
+      headers: {
+        Authorization: `Bearer ${token?.value}`,
+      },
+      next: {
+        tags: ['auth'],
+      },
+    })
+    const data = await res.json()
+    return data
+  } catch (e) {
+    return null
+  }
+}
+
 export default async function Header() {
-  const data = validateToken()
+  const currentUser = await getCurrentUser()
 
   let systemDarkmode = false
   if (typeof window !== 'undefined') {
@@ -33,13 +56,13 @@ export default async function Header() {
         <NotificationButton />
         <DarkModeButton darkMode={darkMode} />
       </div>
-      {!data ? (
+      {!currentUser ? (
         <div className="sign-container">
           <LinkButton href={APP_PATH.login()}>로그인</LinkButton>
           <LinkButton href={APP_PATH.register()}>회원가입</LinkButton>
         </div>
       ) : (
-        <AvatarDropdown darkmode={darkMode} />
+        <AvatarDropdown darkmode={darkMode} currentUser={currentUser} />
       )}
     </div>
   )

--- a/src/components/templates/HomePageTemplate/index.tsx
+++ b/src/components/templates/HomePageTemplate/index.tsx
@@ -1,5 +1,0 @@
-import React from 'react'
-
-export default function HomePageTemplate() {
-  return <div>HomePageTemplate</div>
-}

--- a/src/config/environments.ts
+++ b/src/config/environments.ts
@@ -1,6 +1,7 @@
 import { assertValue } from '@/utils/assertValue'
 
 export const Environment = {
+  internalUrl: () => assertEnv('NEXT_PUBLIC_API_INTERNAL_ADDRESS'),
   nodeEnv: () => process.env.NODE_ENV,
   baseUrl: () => assertEnv('NEXT_PUBLIC_API_ADDRESS'),
   channelId: () => assertEnv('NEXT_PUBLIC_CHANNEL_ID'),

--- a/src/hooks/useLogin.ts
+++ b/src/hooks/useLogin.ts
@@ -1,7 +1,5 @@
 import { AxiosError } from 'axios'
-import { useRouter } from 'next/navigation'
 import { notify } from '@/components/atoms/Toast'
-import APP_PATH from '@/config/paths'
 import { SIGN_CONSTANT } from '@/constants/sign'
 import { loginUser } from '@/services/auth'
 
@@ -11,12 +9,11 @@ export interface LoginReqBody {
 }
 
 export const useLogin = () => {
-  const router = useRouter()
   const login = async ({ email, password }: LoginReqBody) => {
     try {
       const res = await loginUser({ email, password })
       if (res) {
-        router.push(APP_PATH.home())
+        location.reload()
       }
     } catch (error) {
       const { response } = error as unknown as AxiosError

--- a/src/hooks/useSignup.ts
+++ b/src/hooks/useSignup.ts
@@ -19,6 +19,7 @@ export const useSignup = () => {
       if (user) {
         notify('success', '회원가입이 성공적으로 완료되었습니다.')
         router.push(APP_PATH.home())
+        location.reload()
         return user
       }
     } catch (error) {

--- a/src/lib/contexts/authProvider.tsx
+++ b/src/lib/contexts/authProvider.tsx
@@ -34,7 +34,6 @@ export function AuthProvider({ children }: AuthProviderProps) {
 
   useEffect(() => {
     if (isLoggedIn && authProhibitedPages.includes(pathname)) {
-      notify('warning', '이미 로그인 되어있습니다.')
       router.push(APP_PATH.home())
     }
     if (!isLoggedIn && authNeededPages.includes(pathname)) {


### PR DESCRIPTION
## - 목적
관련 이슈: #258
-

<br>

## - 주요 변경 사항

- header에서 유저 프로필을 로드하는 방식을 SSR로 전환
- 로그인, 로그아웃, 회원가입에 대해 리로드하는 방식으로 `location.reload()` 처리로 통일

## 기타 사항 (선택)

- `location.reload()`로 하는 것에 대한 거부감이 있었는데, 생각해보니 매번 로그인, 로그아웃이 되는 것도 아니고 적합한 동작이 아닌가 싶어 전환했는데 의견 부탁드립니다.

<br>

## - 스크린샷 (선택)
