### PR TITLE
:sparkles: 유저 목록 및 포스트 로딩 방식 수정

### DIFF
--- a/src/app/(root)/(routes)/(home)/page.tsx
+++ b/src/app/(root)/(routes)/(home)/page.tsx
@@ -1,29 +1,16 @@
-'use client'
-
 import React from 'react'
-import { useRouter } from 'next/navigation'
+import Link from 'next/link'
 import CirclePlusButton from '@/components/atoms/CirclePlusButton'
-import CardGridTemplate from '@/components/templates/CardGridTemplate'
+import HydrateCardGrid from '@/components/templates/CardGridTemplate/HydrateCardGrid'
 import APP_PATH from '@/config/paths'
-import { useCurrentUser } from '@/hooks/useCurrentUser'
-import { useInfiniteScroll } from '@/hooks/useInfiniteScroll'
-import useGetAllPosts from '@/queries/channel'
 
 export default function Home() {
-  const { currentUser } = useCurrentUser()
-  const { data, fetchNextPage, hasNextPage } = useGetAllPosts(currentUser)
-
-  const { observerElem } = useInfiniteScroll({ fetchNextPage, hasNextPage })
-  const router = useRouter()
-
   return (
     <>
-      <CardGridTemplate
-        postDatas={data?.pages.flat() ?? []}
-        ref={observerElem}
-        isShowOptions={false}
-      />
-      <CirclePlusButton onClick={() => router.push(APP_PATH.postNew())} />
+      <HydrateCardGrid />
+      <Link href={APP_PATH.postNew()}>
+        <CirclePlusButton />
+      </Link>
     </>
   )
 }

--- a/src/app/api/follow/create/route.ts
+++ b/src/app/api/follow/create/route.ts
@@ -14,7 +14,7 @@ export async function POST(request: Request) {
     const followId = followData._id
     const userId = followData.user
 
-    const { data: notiData } = await apiServer.post(
+    await apiServer.post(
       `/notifications/create`,
       {
         notificationType: 'FOLLOW',
@@ -28,8 +28,6 @@ export async function POST(request: Request) {
         },
       },
     )
-
-    console.log(notiData)
 
     return NextResponse.json(followData)
   } catch (error: any) {

--- a/src/components/atoms/CirclePlusButton/CirclePlusButton.tsx
+++ b/src/components/atoms/CirclePlusButton/CirclePlusButton.tsx
@@ -2,13 +2,9 @@ import Image from 'next/image'
 import Assets from '@/config/assets'
 import './index.scss'
 
-type CirclePlusButtonProps = {
-  onClick: React.MouseEventHandler<HTMLButtonElement>
-}
-
-export default function CirclePlusButton({ onClick }: CirclePlusButtonProps) {
+export default function CirclePlusButton() {
   return (
-    <button onClick={onClick} className="circle-plus-button">
+    <button className="circle-plus-button">
       <Image src={Assets.PlusIcon} alt="글 작성 버튼" />
     </button>
   )

--- a/src/components/atoms/ImageButton/imageButton.tsx
+++ b/src/components/atoms/ImageButton/imageButton.tsx
@@ -6,7 +6,7 @@ type ImageButtonProps = {
   size?: number
   src: string
   alt?: string
-  onClick: () => void
+  onClick?: () => void
 }
 
 export default function ImageButton({

--- a/src/components/organisms/CardPostItem/CardPostItem.tsx
+++ b/src/components/organisms/CardPostItem/CardPostItem.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import Image from 'next/image'
 import Link from 'next/link'
 import Avatar from '@/components/atoms/Avatar'
@@ -28,6 +28,12 @@ export default function CardPostItem({
   likes,
 }: CardPostItemProps) {
   const [isDeleted, setIsDeleted] = useState(false)
+  const [parsedDescription, setParsedDescription] = useState('')
+
+  useEffect(() => {
+    setParsedDescription(htmlTagParser(description))
+  }, [description])
+
   return (
     <>
       {!isDeleted && (
@@ -68,7 +74,7 @@ export default function CardPostItem({
                     overflow: 'hidden',
                   }}
                 >
-                  {htmlTagParser(description)}
+                  {parsedDescription}
                 </Text>
               )}
             </Link>

--- a/src/components/organisms/LogInForm/LoginForm.tsx
+++ b/src/components/organisms/LogInForm/LoginForm.tsx
@@ -28,7 +28,6 @@ const LogInForm = () => {
     <form
       className="login-form"
       onSubmit={handleSubmit(async (data) => {
-        console.log('로그인 시도')
         const user = await login({
           email: data.id,
           password: data.password,

--- a/src/components/organisms/NavBar/NavBar.tsx
+++ b/src/components/organisms/NavBar/NavBar.tsx
@@ -1,66 +1,17 @@
-'use client'
-
 import Link from 'next/link'
-import { useRouter } from 'next/navigation'
-import Avatar from '@/components/atoms/Avatar'
-import FollowToggleButton from '@/components/atoms/FollowToggleButton'
 import ImageButton from '@/components/atoms/ImageButton'
-import { Text } from '@/components/atoms/Text'
 import Assets from '@/config/assets'
 import APP_PATH from '@/config/paths'
-import useFollow from '@/hooks/useFollow'
-import useGetAllUsers from '@/queries/users'
-import User from '@/types/user'
+import HydratedUserList from './UserList/HydratedUserList'
 import './index.scss'
 
 export default function NavBar() {
-  const router = useRouter()
-  const { data } = useGetAllUsers()
-
   return (
     <div className="nav-container color-bg--bg-1">
-      <ImageButton
-        src={Assets.MainLogo}
-        onClick={() => router.push(APP_PATH.home())}
-        shape="square"
-      />
-      <div className="nav-title">
-        <Text textStyle="heading1-bold">전체 사용자</Text>
-        <div className="user-count color-bg--highlight">
-          <Text textStyle="caption1-bold" color="bg-2">
-            {data?.length.toString() || ''}
-          </Text>
-        </div>
-      </div>
-      <ul className="avatar-list">
-        {data?.map((user) => <UserListItem key={user._id} userData={user} />)}
-      </ul>
+      <Link href={APP_PATH.home()}>
+        <ImageButton src={Assets.MainLogo} shape="square" />
+      </Link>
+      <HydratedUserList />
     </div>
-  )
-}
-
-function UserListItem({ userData }: { userData: User<string> }) {
-  const { isFollowing, followToggle, followerCount, unavailable } =
-    useFollow(userData)
-  const { image, _id, fullName } = userData
-  return (
-    <li className="avatar-list__item">
-      <div className="avatar-list__item--avatar">
-        <Link href={APP_PATH.userProfile(_id)} prefetch={false}>
-          <Avatar
-            src={image}
-            size={3}
-            text={fullName}
-            subText={`${followerCount} Followers`}
-          />
-        </Link>
-      </div>
-      <FollowToggleButton
-        size="micro"
-        isFollowing={isFollowing}
-        followToggle={followToggle}
-        unavailable={unavailable}
-      />
-    </li>
   )
 }

--- a/src/components/organisms/NavBar/UserList/HydratedUserList.tsx
+++ b/src/components/organisms/NavBar/UserList/HydratedUserList.tsx
@@ -1,0 +1,16 @@
+import { Hydrate, dehydrate } from '@tanstack/react-query'
+import getQueryClient from '@/lib/queryClient'
+import { getAllUsers } from '@/services/user'
+import UserList from './UserList'
+
+export default async function HydratedUserList() {
+  const queryClient = getQueryClient()
+  await queryClient.prefetchQuery(['getAllUsers'], getAllUsers)
+  const dehydratedState = dehydrate(queryClient)
+
+  return (
+    <Hydrate state={dehydratedState}>
+      <UserList />
+    </Hydrate>
+  )
+}

--- a/src/components/organisms/NavBar/UserList/UserList.tsx
+++ b/src/components/organisms/NavBar/UserList/UserList.tsx
@@ -2,7 +2,6 @@
 
 import Link from 'next/link'
 import Avatar from '@/components/atoms/Avatar'
-import FollowToggleButton from '@/components/atoms/FollowToggleButton'
 import { Text } from '@/components/atoms/Text'
 import APP_PATH from '@/config/paths'
 import useFollow from '@/hooks/useFollow'
@@ -29,8 +28,7 @@ export default function UserList() {
 }
 
 function UserListItem({ userData }: { userData: User<string> }) {
-  const { isFollowing, followToggle, followerCount, unavailable } =
-    useFollow(userData)
+  const { followerCount } = useFollow(userData)
   const { image, _id, fullName } = userData
   return (
     <li className="avatar-list__item">
@@ -44,12 +42,6 @@ function UserListItem({ userData }: { userData: User<string> }) {
           />
         </Link>
       </div>
-      <FollowToggleButton
-        size="micro"
-        isFollowing={isFollowing}
-        followToggle={followToggle}
-        unavailable={unavailable}
-      />
     </li>
   )
 }

--- a/src/components/organisms/NavBar/UserList/UserList.tsx
+++ b/src/components/organisms/NavBar/UserList/UserList.tsx
@@ -1,0 +1,55 @@
+'use client'
+
+import Link from 'next/link'
+import Avatar from '@/components/atoms/Avatar'
+import FollowToggleButton from '@/components/atoms/FollowToggleButton'
+import { Text } from '@/components/atoms/Text'
+import APP_PATH from '@/config/paths'
+import useFollow from '@/hooks/useFollow'
+import useGetAllUsers from '@/queries/users'
+import User from '@/types/user'
+
+export default function UserList() {
+  const { data } = useGetAllUsers()
+  return (
+    <>
+      <div className="nav-title">
+        <Text textStyle="heading1-bold">전체 사용자</Text>
+        <div className="user-count color-bg--highlight">
+          <Text textStyle="caption1-bold" color="bg-2">
+            {data?.length.toString() ?? ''}
+          </Text>
+        </div>
+      </div>
+      <ul className="avatar-list">
+        {data?.map((user) => <UserListItem key={user._id} userData={user} />)}
+      </ul>
+    </>
+  )
+}
+
+function UserListItem({ userData }: { userData: User<string> }) {
+  const { isFollowing, followToggle, followerCount, unavailable } =
+    useFollow(userData)
+  const { image, _id, fullName } = userData
+  return (
+    <li className="avatar-list__item">
+      <div className="avatar-list__item--avatar">
+        <Link href={APP_PATH.userProfile(_id)} prefetch={false}>
+          <Avatar
+            src={image}
+            size={3}
+            text={fullName}
+            subText={`${followerCount} Followers`}
+          />
+        </Link>
+      </div>
+      <FollowToggleButton
+        size="micro"
+        isFollowing={isFollowing}
+        followToggle={followToggle}
+        unavailable={unavailable}
+      />
+    </li>
+  )
+}

--- a/src/components/templates/CardGridTemplate/GridController.tsx
+++ b/src/components/templates/CardGridTemplate/GridController.tsx
@@ -1,0 +1,19 @@
+'use client'
+
+import { useInfiniteScroll } from '@/hooks/useInfiniteScroll'
+import useGetAllPosts from '@/queries/channel'
+import CardGridTemplate from '.'
+
+export default function GridController() {
+  const { data, fetchNextPage, hasNextPage } = useGetAllPosts()
+
+  const { observerElem } = useInfiniteScroll({ fetchNextPage, hasNextPage })
+
+  return (
+    <CardGridTemplate
+      postDatas={data?.pages.flat() ?? []}
+      ref={observerElem}
+      isShowOptions={false}
+    />
+  )
+}

--- a/src/components/templates/CardGridTemplate/HydrateCardGrid.tsx
+++ b/src/components/templates/CardGridTemplate/HydrateCardGrid.tsx
@@ -1,0 +1,25 @@
+import { Hydrate, dehydrate } from '@tanstack/react-query'
+import { constants } from '@/config/constants'
+import getQueryClient from '@/lib/queryClient'
+import { getAllPosts } from '@/services/channel'
+import GridController from './GridController'
+
+export default async function HydrateCardGrid() {
+  const queryClient = getQueryClient()
+  await queryClient.prefetchInfiniteQuery(
+    ['getAllPostsInfiniteQuery'],
+    ({ pageParam = 0 }) =>
+      getAllPosts({
+        limit: constants.INFINITE_LIMIT,
+        offset: pageParam,
+      }),
+  )
+
+  const dehydratedState = dehydrate(queryClient)
+
+  return (
+    <Hydrate state={dehydratedState}>
+      <GridController />
+    </Hydrate>
+  )
+}

--- a/src/lib/queryClient.ts
+++ b/src/lib/queryClient.ts
@@ -1,0 +1,5 @@
+import { cache } from 'react'
+import { QueryClient } from '@tanstack/react-query'
+
+const getQueryClient = cache(() => new QueryClient())
+export default getQueryClient

--- a/src/queries/channel/index.ts
+++ b/src/queries/channel/index.ts
@@ -1,17 +1,16 @@
 import { useInfiniteQuery } from '@tanstack/react-query'
 import { constants } from '@/config/constants'
 import { getAllPosts } from '@/services/channel'
-import User from '@/types/user'
 
-const useGetAllPosts = (user?: User) => {
+const useGetAllPosts = () => {
   return useInfiniteQuery({
-    queryKey: ['getAllPostsInfiniteQuery', user?.fullName, user?.image],
+    queryKey: ['getAllPostsInfiniteQuery'],
     queryFn: ({ pageParam = 0 }) =>
       getAllPosts({
         offset: pageParam,
         limit: constants.INFINITE_LIMIT,
       }),
-    getNextPageParam: (lastPage, allPages) => allPages.flat().length,
+    getNextPageParam: (_lastPage, allPages) => allPages.flat().length,
   })
 }
 

--- a/src/queries/users/index.ts
+++ b/src/queries/users/index.ts
@@ -1,15 +1,10 @@
-'use client'
-
 import { useQuery } from '@tanstack/react-query'
-import { useCurrentUser } from '@/hooks/useCurrentUser'
 import { getAllUsers } from '@/services/user'
 import type User from '@/types/user'
 
 const useGetAllUsers = () => {
-  const { currentUser } = useCurrentUser()
-
   return useQuery({
-    queryKey: ['getAllUsers', currentUser?._id],
+    queryKey: ['getAllUsers'],
     queryFn: async () => {
       const data: User<string>[] = await getAllUsers()
       return data

--- a/src/utils/htmlTagParser.ts
+++ b/src/utils/htmlTagParser.ts
@@ -1,19 +1,23 @@
-type HTMLTagParserType = (_htmlString: string) => string | null
+type HTMLTagParserType = (_htmlString: string) => string
 
 const elementsToCheck = ['p', 'h6', 'h5', 'h4', 'h3', 'h2', 'h1']
 
 const htmlTagParser: HTMLTagParserType = (htmlString) => {
-  const parser = new DOMParser()
-  const doc = parser.parseFromString(htmlString, 'text/html')
+  try {
+    const parser = new DOMParser()
+    const doc = parser.parseFromString(htmlString, 'text/html')
 
-  for (const elementName of elementsToCheck) {
-    const element = doc.querySelector(elementName)
-    if (element) {
-      return element.textContent
+    for (const elementName of elementsToCheck) {
+      const element = doc.querySelector(elementName)
+      if (element) {
+        return element.textContent ?? ''
+      }
     }
-  }
 
-  return null
+    return ''
+  } catch (e) {
+    return ''
+  }
 }
 
 export default htmlTagParser


### PR DESCRIPTION
## - 목적
관련 이슈: #260
-

<br>

## - 주요 변경 사항

- 유저 목록에 대한 사전 dehydrate state 전달
- 유저 목록 옆 팔로우 버튼 삭제
- 홈 페이지 포스트에 대한 prefetch

## 기타 사항 (선택)

- c2c0e0a7e371bdb3a3c99565039cf12829090660 커밋에 대해 의견 남겨주세요
- SSR로 state를 전달하면 상세 유저 페이지에서 팔로우, 팔로우의 여부가 즉시 사이드바와 동기화되지 않습니다... 라 작성하던 중에 보니까 애초에 CSR 배포 버전에서도 안 되네요.
- 그리고 인스타 등을 봤더니 같은 대상에 대한 팔로우 버튼이 한 화면에 있는 경우가 없더군요... (역시 이유가 있는 디자인...)
- 즉, 화면에 같은 대상에 대한 팔로우 버튼을 동기화 하는데 사용되는 비용과 비교한 trade off라고 생각합니다.

<br>

## - 스크린샷 (선택)
