### PR TITLE
✨ 좋아요 싫어요 상태별 이미지 추가, 취소 가능하게 설정

### DIFF
--- a/src/app/(root)/(routes)/post/[postId]/page.tsx
+++ b/src/app/(root)/(routes)/post/[postId]/page.tsx
@@ -17,7 +17,6 @@ export default async function Post({ params }: PostPageProps) {
     <PostDetailTemplate
       initDisLikeChannelPost={initPost.disLikePost}
       initPost={initPost.post}
-      mapping_ID={JSON.parse(initPost.post.title).mapping_ID || ''}
       postId={params.postId}
     />
   )

--- a/src/components/molcules/LikeDislikeCount/LikeDislikeCount.tsx
+++ b/src/components/molcules/LikeDislikeCount/LikeDislikeCount.tsx
@@ -9,7 +9,7 @@ export type LikeDislikeCountProps = {
   dislike: number
   onClickLike?: () => Promise<void>
   onClickDisLike?: () => Promise<void>
-  initalState: 'like' | 'dislike' | 'init'
+  initalState: 'like' | 'dislike' | 'init' | 'both'
 }
 export default function LikeDislikeCount({
   like,

--- a/src/components/molcules/LikeDislikeCount/LikeDislikeCount.tsx
+++ b/src/components/molcules/LikeDislikeCount/LikeDislikeCount.tsx
@@ -9,6 +9,7 @@ export type LikeDislikeCountProps = {
   dislike: number
   onClickLike?: () => Promise<void>
   onClickDisLike?: () => Promise<void>
+  initalState: 'like' | 'dislike' | 'init'
 }
 export default function LikeDislikeCount({
   like,

--- a/src/components/molcules/LikeDislikeCount/index.stories.ts
+++ b/src/components/molcules/LikeDislikeCount/index.stories.ts
@@ -11,6 +11,7 @@ type Story = StoryObj<typeof meta>
 
 export const Default: Story = {
   args: {
+    initalState: 'init',
     like: 230,
     dislike: 180,
   },

--- a/src/components/organisms/CardPostItem/CardPostItem.tsx
+++ b/src/components/organisms/CardPostItem/CardPostItem.tsx
@@ -73,6 +73,7 @@ export default function CardPostItem({
               )}
             </Link>
             <LikeDislikeCount
+              initalState="init"
               like={likes.length ?? 0}
               dislike={disLikes?.length ?? 0}
             />

--- a/src/components/organisms/LikeDIsLikeProgressBar/index.stories.tsx
+++ b/src/components/organisms/LikeDIsLikeProgressBar/index.stories.tsx
@@ -11,6 +11,7 @@ type Story = StoryObj<typeof meta>
 
 export const Default: Story = {
   args: {
+    initalState: 'init',
     like: 230,
     dislike: 180,
   },

--- a/src/components/organisms/LikeDIsLikeProgressBar/index.tsx
+++ b/src/components/organisms/LikeDIsLikeProgressBar/index.tsx
@@ -12,9 +12,8 @@ export default function LikeDisLikeProgressBar({
 
   return (
     <ProgressBar
-      animateOnRender
       completed={ratio}
-      width={`${569 / 16}rem`}
+      width={`27vw`}
       height={`${30 / 16}rem`}
       bgColor="#ffdf5f"
       baseBgColor="#fffaea"

--- a/src/components/organisms/LikeDisLikeContainer/LikeDIsLikeContainer.tsx
+++ b/src/components/organisms/LikeDisLikeContainer/LikeDIsLikeContainer.tsx
@@ -60,7 +60,11 @@ export default function LikeDislikeContainer({
       <>
         <span className="like-container__likes">
           <Image
-            src={likeState === 'like' ? Assets.ActiveLike : likeImage}
+            src={
+              likeState === 'like' || likeState === 'both'
+                ? Assets.ActiveLike
+                : likeImage
+            }
             alt="좋아요 이미지"
             width={30}
             height={30}
@@ -80,7 +84,11 @@ export default function LikeDislikeContainer({
         />
         <span className="like-container__dislikes">
           <Image
-            src={likeState === 'dislike' ? Assets.ActiveDisLike : disLikeImage}
+            src={
+              likeState === 'dislike' || likeState === 'both'
+                ? Assets.ActiveDisLike
+                : disLikeImage
+            }
             alt="싫어요 이미지"
             width={30}
             height={30}

--- a/src/components/organisms/LikeDisLikeContainer/LikeDIsLikeContainer.tsx
+++ b/src/components/organisms/LikeDisLikeContainer/LikeDIsLikeContainer.tsx
@@ -5,6 +5,7 @@ import Image from 'next/image'
 import { Text } from '@/components/atoms/Text'
 import type { LikeDislikeCountProps } from '@/components/molcules/LikeDislikeCount/LikeDislikeCount'
 import Assets from '@/config/assets'
+import useLikeState from '@/hooks/useLikeState'
 import useDarkStore from '@/stores/darkMode'
 import LikeDisLikeProgressBar from '../LikeDIsLikeProgressBar'
 import './index.scss'
@@ -14,13 +15,20 @@ export default function LikeDislikeContainer({
   dislike,
   onClickLike,
   onClickDisLike,
+  initalState,
 }: LikeDislikeCountProps) {
   const [loading, setLoading] = useState(false)
   const { isDark } = useDarkStore()
+  const { toggleDisLikeState, toggleLikeState, likeState } =
+    useLikeState(initalState)
 
   const likeImage = isDark ? Assets.DarkLike : Assets.LikeImage
+
   const disLikeImage = isDark ? Assets.DarkDisLike : Assets.DislikeImage
+
   const handleClickLike = useCallback(() => {
+    toggleLikeState()
+
     if (onClickLike) {
       setLoading(true)
       onClickLike()
@@ -31,9 +39,10 @@ export default function LikeDislikeContainer({
           setLoading(false)
         })
     }
-  }, [onClickLike])
+  }, [onClickLike, toggleLikeState])
 
   const handleClickDisLike = useCallback(() => {
+    toggleDisLikeState()
     if (onClickDisLike) {
       setLoading(true)
       onClickDisLike()
@@ -44,14 +53,14 @@ export default function LikeDislikeContainer({
           setLoading(false)
         })
     }
-  }, [onClickDisLike])
+  }, [onClickDisLike, toggleDisLikeState])
 
   return (
     <div className="like-container">
       <>
         <span className="like-container__likes">
           <Image
-            src={likeImage}
+            src={likeState === 'like' ? Assets.ActiveLike : likeImage}
             alt="좋아요 이미지"
             width={30}
             height={30}
@@ -64,10 +73,14 @@ export default function LikeDislikeContainer({
           <Text textStyle="subtitle1-bold">잘 샀어요</Text>
           <span>{like}</span>
         </span>
-        <LikeDisLikeProgressBar like={like} dislike={dislike} />
+        <LikeDisLikeProgressBar
+          like={like}
+          dislike={dislike}
+          initalState="init"
+        />
         <span className="like-container__dislikes">
           <Image
-            src={disLikeImage}
+            src={likeState === 'dislike' ? Assets.ActiveDisLike : disLikeImage}
             alt="싫어요 이미지"
             width={30}
             height={30}

--- a/src/components/organisms/LikeDisLikeContainer/index.scss
+++ b/src/components/organisms/LikeDisLikeContainer/index.scss
@@ -24,12 +24,15 @@
   margin: 0 auto;
   margin-bottom: 15px;
   gap: 2px;
+  overflow: hidden;
+
   @include themed() {
     color: t(gray-5);
   }
   &__likes {
     display: flex;
     align-items: center;
+    overflow: hidden;
     gap: 3px;
   }
 

--- a/src/components/organisms/LikeDisLikeContainer/index.stories.tsx
+++ b/src/components/organisms/LikeDisLikeContainer/index.stories.tsx
@@ -11,6 +11,7 @@ type Story = StoryObj<typeof meta>
 
 export const Default: Story = {
   args: {
+    initalState: 'init',
     like: 230,
     dislike: 180,
   },

--- a/src/components/organisms/SearchPostItem/SearchPostItem.tsx
+++ b/src/components/organisms/SearchPostItem/SearchPostItem.tsx
@@ -50,6 +50,7 @@ export default function SearchPostItem({
             )}
           </Link>
           <LikeDislikeCount
+            initalState="init"
             like={likes.length ?? 0}
             dislike={disLikes?.length ?? 0}
           />

--- a/src/components/templates/PostDetailTemplate/PostDetailTemplate.tsx
+++ b/src/components/templates/PostDetailTemplate/PostDetailTemplate.tsx
@@ -1,22 +1,21 @@
 'use client'
 
-import React, { useCallback, useState, useMemo } from 'react'
+import React, { useMemo } from 'react'
 import parse from 'html-react-parser'
 import Image from 'next/image'
 import Link from 'next/link'
 import Avatar from '@/components/atoms/Avatar'
 import { Text } from '@/components/atoms/Text'
-import { notify } from '@/components/atoms/Toast'
 import PostOptionsDropdown from '@/components/molcules/PostOptionsDropdown'
 import CommentInput from '@/components/organisms/CommentInput/CommentInput'
 import CommentListContainer from '@/components/organisms/CommentList/CommentListContainer'
 import { LikeDisLikeContainer } from '@/components/organisms/LikeDisLikeContainer'
 import APP_PATH from '@/config/paths'
-import { POST_CONSTANT } from '@/constants/post'
+import useDisLike from '@/hooks/useDisLike'
+import useLike from '@/hooks/useLike'
 import { useAuth } from '@/lib/contexts/authProvider'
 import { postNewComment } from '@/services/comment'
 import { getPostDetail } from '@/services/post'
-import { postLikeAction, postLikeCancelAction } from '@/services/post/like'
 import Post from '@/types/post'
 import './index.scss'
 
@@ -24,14 +23,12 @@ type PostDetailTemplateProps = {
   postId: string
   initPost: Post
   initDisLikeChannelPost: Post
-  mapping_ID: string
 }
 
 export function PostDetailTemplate({
   postId,
   initPost,
   initDisLikeChannelPost,
-  mapping_ID,
 }: PostDetailTemplateProps) {
   const { title, comment, image, author, _id } = initPost
   const { currentUser, isLoggedIn } = useAuth()
@@ -40,156 +37,42 @@ export function PostDetailTemplate({
   const cachedCurrentUser = useMemo(() => currentUser, [currentUser])
   const isEqualUser = cachedCurrentUser?._id === author._id
 
-  const [likeChannelPost, setLikeChannelPost] = useState<Post>(initPost)
-  const [dislikeChannelPost, setDislikeChannelPost] = useState<Post>(
-    initDisLikeChannelPost,
+  const { post, handleOnClickLike, setLikePost } = useLike({
+    initPost,
+    disLikePost: initDisLikeChannelPost,
+    postId: initPost._id,
+    fetchDisLike: () =>
+      getPostDetail(initDisLikeChannelPost._id).then(({ post }) =>
+        setDisLikePost(post),
+      ),
+  })
+  const {
+    post: disLikePost,
+    handleOnClickDisLike,
+    setDisLikePost,
+  } = useDisLike({
+    initPost: initDisLikeChannelPost,
+    likePost: initDisLikeChannelPost,
+    postId: initDisLikeChannelPost._id,
+    fetchLike: () =>
+      getPostDetail(initDisLikeChannelPost._id).then(({ post }) =>
+        setLikePost(post),
+      ),
+  })
+
+  const initLikeState = post.likes.some(
+    (like) => like.user === currentUser?._id,
+  )
+  const initDisLikeState = disLikePost.likes.some(
+    (dislike) => dislike.user === currentUser?._id,
   )
 
+  const initState = initLikeState
+    ? 'like'
+    : initDisLikeState
+    ? 'dislike'
+    : 'init'
   //좋아요를 누른 상태라면 좋아요 취소 요청을 보내고 싫어요 요청 ㄱ
-
-  const handleOnClickLikeBtn = useCallback(async () => {
-    if (!isLoggedIn) {
-      notify('error', POST_CONSTANT.LIKE_ERROR)
-      return
-    }
-
-    try {
-      const { _id, likes } = likeChannelPost
-
-      const { _id: _dislikeChannelId, likes: _dislikeChannelLikes } =
-        dislikeChannelPost
-
-      const hasLikedPost = likes.some(
-        (like) => like.user === cachedCurrentUser?._id,
-      )
-      const hasDisLikedPost = _dislikeChannelLikes.some(
-        (like) => like.user === cachedCurrentUser?._id,
-      )
-
-      //좋아요를 아직 하지 않은 경우 좋아요 요청을 보내고 싫어요 취소 요청
-      if (!hasLikedPost) {
-        await postLikeAction(_id)
-        await getPostDetail(_id).then(({ post }) => {
-          setLikeChannelPost(post)
-        })
-
-        if (hasDisLikedPost) {
-          const disLikeID = dislikeChannelPost.likes.filter(
-            (like) => like.user === cachedCurrentUser?._id,
-          )[0]._id
-          await postLikeCancelAction(disLikeID)
-          await getPostDetail(mapping_ID).then(({ post }) => {
-            setDislikeChannelPost(post)
-          })
-        }
-
-        return
-      }
-
-      //좋아요를 한 경우
-      //좋아요의 ID를 뽑아옴
-      else {
-        const likeId = likes.filter(
-          (like) => like.user === cachedCurrentUser?._id,
-        )[0]._id
-
-        await postLikeCancelAction(likeId)
-        await getPostDetail(_id).then(({ post }) => {
-          setLikeChannelPost(post)
-        })
-        if (!hasDisLikedPost) {
-          await postLikeAction(mapping_ID)
-          await getPostDetail(mapping_ID).then(({ post }) => {
-            setDislikeChannelPost(post)
-          })
-        }
-
-        return
-      }
-    } catch (error) {
-      notify('error', POST_CONSTANT.LIKE_API_ERROR)
-    }
-  }, [
-    isLoggedIn,
-    likeChannelPost,
-    dislikeChannelPost,
-    cachedCurrentUser?._id,
-    mapping_ID,
-  ])
-
-  //싫어요를 누른 상태라면 싫어요 취소 요청을 보내고 좋아요 요청 ㄱ
-  //싫어요를 누르지 않은 상태라면 싫어요 요청을 보내고 좋아요 취소 요청 ㄱ
-
-  const handleOnClickDisLikeBtn = useCallback(async () => {
-    if (!isLoggedIn) {
-      notify('error', POST_CONSTANT.DISLIKE_ERROR)
-      return
-    }
-
-    try {
-      //TODO - 해당 validate 분리. 검증 조건 추가 필요
-      if (typeof mapping_ID !== 'string' || mapping_ID.length < 1) {
-        return
-      }
-
-      const { likes } = dislikeChannelPost
-
-      const hasLikedPost = likeChannelPost.likes.some(
-        (like) => like.user === cachedCurrentUser?._id,
-      )
-
-      //해당 게시글을 싫어요를 했는지?
-      const hasDislikedPost = likes.some(
-        (disLike) => disLike.user === cachedCurrentUser?._id,
-      )
-
-      //아직 싫어요를 안한 경우
-      if (!hasDislikedPost) {
-        await postLikeAction(mapping_ID)
-        await getPostDetail(mapping_ID).then(({ post }) => {
-          setDislikeChannelPost(post)
-        })
-
-        if (hasLikedPost) {
-          const likeId = likeChannelPost.likes.filter(
-            (like) => like.user === cachedCurrentUser?._id,
-          )[0]._id
-          await postLikeCancelAction(likeId)
-          await getPostDetail(likeChannelPost._id).then(({ post }) => {
-            setLikeChannelPost(post)
-          })
-        }
-
-        return
-      }
-
-      //싫어요를 이미 한 경우
-      else {
-        const disLikeID = likes.filter(
-          (like) => like.user === cachedCurrentUser?._id,
-        )[0]._id
-        await postLikeCancelAction(disLikeID)
-        await getPostDetail(mapping_ID).then(({ post }) => {
-          setDislikeChannelPost(post)
-        })
-
-        await postLikeAction(likeChannelPost._id)
-        await getPostDetail(likeChannelPost._id).then(({ post }) => {
-          setLikeChannelPost(post)
-        })
-        return
-      }
-    } catch (error) {
-      notify('error', POST_CONSTANT.DISLIKE_API_ERROR)
-    }
-  }, [
-    isLoggedIn,
-    mapping_ID,
-    dislikeChannelPost,
-    likeChannelPost.likes,
-    likeChannelPost._id,
-    cachedCurrentUser?._id,
-  ])
 
   return (
     <div className="post-detail">
@@ -221,10 +104,11 @@ export function PostDetailTemplate({
       </div>
 
       <LikeDisLikeContainer
-        like={likeChannelPost?.likes?.length || 0}
-        dislike={dislikeChannelPost?.likes?.length || 0}
-        onClickLike={handleOnClickLikeBtn}
-        onClickDisLike={handleOnClickDisLikeBtn}
+        initalState={initState}
+        like={post?.likes?.length || 0}
+        dislike={disLikePost?.likes?.length || 0}
+        onClickLike={handleOnClickLike}
+        onClickDisLike={handleOnClickDisLike}
       />
       <CommentListContainer postId={postId} initComments={comment} />
       {isLoggedIn && currentUser && (

--- a/src/components/templates/PostDetailTemplate/PostDetailTemplate.tsx
+++ b/src/components/templates/PostDetailTemplate/PostDetailTemplate.tsx
@@ -52,12 +52,10 @@ export function PostDetailTemplate({
     setDisLikePost,
   } = useDisLike({
     initPost: initDisLikeChannelPost,
-    likePost: initDisLikeChannelPost,
+    likePost: initPost,
     postId: initDisLikeChannelPost._id,
-    fetchLike: () =>
-      getPostDetail(initDisLikeChannelPost._id).then(({ post }) =>
-        setLikePost(post),
-      ),
+    fetchLike: async () =>
+      await getPostDetail(initPost._id).then(({ post }) => setLikePost(post)),
   })
 
   const initLikeState = post.likes.some(
@@ -67,11 +65,14 @@ export function PostDetailTemplate({
     (dislike) => dislike.user === currentUser?._id,
   )
 
-  const initState = initLikeState
-    ? 'like'
-    : initDisLikeState
-    ? 'dislike'
-    : 'init'
+  const initState =
+    initLikeState && initDisLikeState
+      ? 'both'
+      : initLikeState
+      ? 'like'
+      : initDisLikeState
+      ? 'dislike'
+      : 'init'
   //좋아요를 누른 상태라면 좋아요 취소 요청을 보내고 싫어요 요청 ㄱ
 
   return (

--- a/src/hooks/useDisLike.ts
+++ b/src/hooks/useDisLike.ts
@@ -1,0 +1,80 @@
+import { useState, useCallback } from 'react'
+import { notify } from '@/components/atoms/Toast'
+import { POST_CONSTANT } from '@/constants/post'
+import { getPostDetail } from '@/services/post'
+import { postLikeAction, postLikeCancelAction } from '@/services/post/like'
+import Post from '@/types/post'
+import { useCurrentUser } from './useCurrentUser'
+
+type useLikeProps = {
+  initPost: Post
+  likePost: Post
+  postId: string
+  fetchLike: () => Promise<Post | void>
+}
+
+export default function useDisLike({
+  initPost,
+  likePost,
+  postId,
+  fetchLike,
+}: useLikeProps) {
+  const [post, setDisLikePost] = useState<Post>(initPost)
+  const { isLoggedIn, currentUser } = useCurrentUser()
+
+  const handleOnClickDisLike = useCallback(async () => {
+    if (!isLoggedIn) {
+      notify('error', POST_CONSTANT.DISLIKE_ERROR)
+      return
+    }
+
+    const hasLikedPost = likePost.likes.some(
+      (like) => like.user === currentUser?._id,
+    )
+
+    //해당 게시글을 싫어요를 했는지?
+    const hasDislikedPost = post.likes.some(
+      (disLike) => disLike.user === currentUser?._id,
+    )
+
+    try {
+      if (!hasDislikedPost) {
+        await postLikeAction(initPost._id)
+        await getPostDetail(postId).then(({ post }) => setDisLikePost(post))
+
+        if (hasLikedPost) {
+          const likeId = likePost.likes.filter(
+            (like) => like.user === currentUser?._id,
+          )[0]._id
+          await postLikeCancelAction(likeId)
+          await fetchLike()
+        }
+
+        return
+      }
+
+      //싫어요를 이미 한 경우
+      else if (hasDislikedPost) {
+        const disLikeID = post.likes.filter(
+          (like) => like.user === currentUser?._id,
+        )[0]._id
+        await postLikeCancelAction(disLikeID)
+
+        await getPostDetail(postId).then(({ post }) => setDisLikePost(post))
+        return
+      }
+    } catch (error) {
+      notify('error', POST_CONSTANT.DISLIKE_API_ERROR)
+    }
+  }, [
+    isLoggedIn,
+    likePost.likes,
+    post.likes,
+    currentUser?._id,
+    initPost._id,
+    postId,
+    fetchLike,
+  ])
+
+  return { handleOnClickDisLike, post, setDisLikePost }
+}

--- a/src/hooks/useLike.ts
+++ b/src/hooks/useLike.ts
@@ -1,0 +1,65 @@
+import { useState, useCallback } from 'react'
+import { notify } from '@/components/atoms/Toast'
+import { POST_CONSTANT } from '@/constants/post'
+import { getPostDetail } from '@/services/post'
+import { postLikeAction, postLikeCancelAction } from '@/services/post/like'
+import Post from '@/types/post'
+import { useCurrentUser } from './useCurrentUser'
+
+type useLikeProps = {
+  postId: string
+  initPost: Post
+  disLikePost: Post
+  fetchDisLike: () => Promise<Post | void>
+}
+
+export default function useLike({
+  initPost,
+  disLikePost,
+  postId,
+  fetchDisLike,
+}: useLikeProps) {
+  const [post, setLikePost] = useState<Post>(initPost)
+  const { isLoggedIn, currentUser } = useCurrentUser()
+
+  const handleOnClickLike = useCallback(async () => {
+    if (!isLoggedIn) {
+      notify('error', POST_CONSTANT.LIKE_ERROR)
+      return
+    }
+
+    try {
+      const { _id, likes } = post
+      const hasLikedPost = likes.some((like) => like.user === currentUser?._id)
+      const hasDisLikedPost = disLikePost.likes.some(
+        (like) => like.user === currentUser?._id,
+      )
+      if (!hasLikedPost) {
+        await postLikeAction(_id)
+        await getPostDetail(postId).then(({ post }) => setLikePost(post))
+
+        if (hasDisLikedPost && currentUser) {
+          const disLikeID = disLikePost.likes.filter(
+            (like) => like.user === currentUser._id,
+          )[0]._id
+          await postLikeCancelAction(disLikeID)
+          await fetchDisLike()
+        }
+
+        return
+      } else if (currentUser) {
+        const likeId = likes.filter((like) => like.user === currentUser._id)[0]
+          ._id
+
+        await postLikeCancelAction(likeId)
+        await getPostDetail(postId).then(({ post }) => setLikePost(post))
+
+        return
+      }
+    } catch (error) {
+      notify('error', POST_CONSTANT.LIKE_API_ERROR)
+    }
+  }, [isLoggedIn, post, disLikePost.likes, currentUser, postId, fetchDisLike])
+
+  return { handleOnClickLike, post, setLikePost }
+}

--- a/src/hooks/useLikeState.ts
+++ b/src/hooks/useLikeState.ts
@@ -1,0 +1,26 @@
+import { useEffect, useState } from 'react'
+
+export default function useLikeState(initState: 'init' | 'like' | 'dislike') {
+  const [likeState, setLikeState] = useState('init')
+  useEffect(() => {
+    setLikeState(initState)
+  }, [initState])
+
+  const toggleLikeState = () => {
+    if (likeState === 'like') {
+      setLikeState('init')
+    } else {
+      setLikeState('like')
+    }
+  }
+
+  const toggleDisLikeState = () => {
+    if (likeState === 'dislike') {
+      setLikeState('init')
+    } else {
+      setLikeState('dislike')
+    }
+  }
+
+  return { likeState, toggleLikeState, toggleDisLikeState }
+}

--- a/src/hooks/useLikeState.ts
+++ b/src/hooks/useLikeState.ts
@@ -1,6 +1,8 @@
 import { useEffect, useState } from 'react'
 
-export default function useLikeState(initState: 'init' | 'like' | 'dislike') {
+export default function useLikeState(
+  initState: 'init' | 'like' | 'dislike' | 'both',
+) {
   const [likeState, setLikeState] = useState('init')
   useEffect(() => {
     setLikeState(initState)


### PR DESCRIPTION
## - 목적
관련 이슈: #267 
-

<br>

## - 주요 변경 사항

- 좋아요 싫어요를 취소할 수 있습니다(유저가 좋아요 누른 상태->다시 누르면 취소)
- 누른 상태에 대해 이미지를 추가했습니다(이전에 좋아요를 눌렀으면 좋아요따봉의 활성화이미지)
- template에서 로직이 너무 많아 훅으로 분리했습니다.

## 기타 사항 (선택)

-

<br>

## - 스크린샷 (선택)

![image](https://github.com/prgrms-fe-devcourse/FEDC4_Price-PCC_DONGYOUNG/assets/59411107/4ecb1271-02de-482f-aede-1697bb59ee5b)

![image](https://github.com/prgrms-fe-devcourse/FEDC4_Price-PCC_DONGYOUNG/assets/59411107/a891df88-01e6-49f2-8201-642bda9ec64c)

