### PR TITLE
:bug: 모달 스크롤 방지

### DIFF
--- a/src/components/molcules/ModalLayout/index.scss
+++ b/src/components/molcules/ModalLayout/index.scss
@@ -1,6 +1,6 @@
 @import '@/styles/variables.scss';
 .modal-background {
-  position: absolute;
+  position: fixed;
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);

--- a/src/components/organisms/FollowList/FollowList.tsx
+++ b/src/components/organisms/FollowList/FollowList.tsx
@@ -19,14 +19,22 @@ export default function FollowList({
         {isFollowerList ? '팔로워' : '팔로잉'}
       </Text>
       <ul className="follow-list">
-        {users?.map(({ _id, user, follower }, index) => {
-          const targetUserId = isFollowerList ? follower : user
-          return (
-            <div key={_id + index}>
-              <FollowListItem targetUserId={targetUserId} />
-            </div>
-          )
-        })}
+        {users?.length === 0 ? (
+          <div className="follow-list__message">
+            <Text textStyle="heading2" color="gray-4">{`${
+              isFollowerList ? '팔로워가' : '팔로우하는 유저가'
+            } 없습니다.`}</Text>
+          </div>
+        ) : (
+          users?.map(({ _id, user, follower }, index) => {
+            const targetUserId = isFollowerList ? follower : user
+            return (
+              <div key={_id + index}>
+                <FollowListItem targetUserId={targetUserId} />
+              </div>
+            )
+          })
+        )}
       </ul>
     </div>
   )

--- a/src/components/organisms/FollowList/index.scss
+++ b/src/components/organisms/FollowList/index.scss
@@ -12,6 +12,12 @@
   overflow: auto;
   height: 30rem;
   padding-right: 1rem;
+  &__message {
+    height: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
   &__item {
     display: flex;
     align-items: center;

--- a/src/components/organisms/UserDetailCard/section/Follows.tsx
+++ b/src/components/organisms/UserDetailCard/section/Follows.tsx
@@ -37,12 +37,12 @@ export default function Follows({ userData }: { userData: User }) {
         <InfoCount
           text="팔로워"
           count={followerCount.toString()}
-          onClick={() => followerCount && handleFollowModalOpen(true)}
+          onClick={() => handleFollowModalOpen(true)}
         />
         <InfoCount
           text="팔로잉"
           count={followingCount.toString()}
-          onClick={() => followingCount && handleFollowModalOpen(false)}
+          onClick={() => handleFollowModalOpen(false)}
         />
       </div>
       <div className="follow_buttons">
@@ -83,11 +83,7 @@ const InfoCount = ({
 }) => {
   return (
     <>
-      <button
-        className="info_count"
-        onClick={onClick}
-        style={{ cursor: `${Number(count) === 0 ? 'auto' : 'pointer'}` }}
-      >
+      <button className="info_count" onClick={onClick}>
         <Text textStyle="body1-bold">{text}</Text>
         <Text textStyle="body1-bold">{count}</Text>
       </button>

--- a/src/hooks/useFollow.ts
+++ b/src/hooks/useFollow.ts
@@ -25,9 +25,10 @@ const useFollow = (userData: User<Follow | string> | undefined) => {
   const [followingCount, setFollowingCount] = useState(0)
 
   useEffect(() => {
-    if (!userData || !currentUser) return
+    if (!userData) return
     setFollowerCount(() => userData.followers?.length ?? 0)
     setFollowingCount(() => userData.following?.length ?? 0)
+    if (!currentUser) return
     setIsFollowing(
       () =>
         currentUser.following?.some(
@@ -43,10 +44,11 @@ const useFollow = (userData: User<Follow | string> | undefined) => {
   }, [currentUser, userData])
 
   const followToggle = async () => {
-    if (!userData || !currentUser) return
+    if (!userData) return
     if (isFollowing) {
       setFollowerCount((prev) => prev - 1)
       setIsFollowing(false)
+      if (!currentUser) return
       const followData = currentUser.following?.find(
         ({ user }) => user === userData._id,
       )
@@ -59,6 +61,7 @@ const useFollow = (userData: User<Follow | string> | undefined) => {
     } else {
       setIsFollowing(true)
       setFollowerCount((prev) => prev + 1)
+      if (!currentUser) return
       const followData = await postFollow(userData._id)
       setFollowId(() => followData._id ?? '')
       currentUser.following?.push(followData)

--- a/src/hooks/useModal.ts
+++ b/src/hooks/useModal.ts
@@ -1,7 +1,15 @@
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 
 export default function useModal() {
   const [isModalOpen, setIsModalOpen] = useState<boolean>(false)
+
+  useEffect(() => {
+    if (isModalOpen) {
+      document.body.style.overflow = 'hidden'
+    } else {
+      document.body.style.overflow = 'visible'
+    }
+  }, [isModalOpen])
 
   const handleModalOpen = () => {
     setIsModalOpen(true)


### PR DESCRIPTION
## - 목적
관련 이슈: #271 
- [a044552](https://github.com/prgrms-fe-devcourse/FEDC4_Price-PCC_DONGYOUNG/pull/281/commits/a044552fee509a5c1cb6ffb5187a9c7febfa45a7), [70dc701](https://github.com/prgrms-fe-devcourse/FEDC4_Price-PCC_DONGYOUNG/pull/281/commits/70dc701457f3accd5c9c6c60bb2b6259bbf36ca3)  두 개만 보시면 됩니다

<br>

## - 주요 변경 사항

- 기존에 유저 프로필 페이지에서 스크롤을 아래로 어느정도 한 상태에서 모달을 켜면 그만큼 위에 뜨는 문제를 수정했습니다.
- 모달을 켠 상태에서는 body 스크롤이 안되도록 useModal 훅 내에 overflow hidden처리 해두었습니다.

## 기타 사항 (선택)

-

<br>

## - 스크린샷 (선택)
