### PR TITLE
🐛 비밀번호 검증 모달, 계정 정보 수정 페이지 버그 수정

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "sweet-trade",
       "version": "0.1.0",
       "dependencies": {
+        "@hookform/resolvers": "^3.3.1",
         "@ramonak/react-progress-bar": "^5.0.3",
         "@tanstack/react-query": "^4.33.0",
         "@types/classnames": "^2.3.1",
@@ -29,6 +30,7 @@
         "react-quill": "^2.0.0",
         "react-toastify": "^9.1.3",
         "typescript": "5.2.2",
+        "zod": "^3.22.2",
         "zustand": "^4.4.1"
       },
       "devDependencies": {
@@ -2934,6 +2936,14 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.1.1.tgz",
       "integrity": "sha512-m0G6wlnhm/AX0H12IOWtK8gASEMffnX08RtKkCgTdHb9JpHKGloI7icFfLg9ZmQeavcvR0PKmzxClyuFPSjKWw==",
       "dev": true
+    },
+    "node_modules/@hookform/resolvers": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-3.3.1.tgz",
+      "integrity": "sha512-K7KCKRKjymxIB90nHDQ7b9nli474ru99ZbqxiqDAWYsYhOsU3/4qLxW91y+1n04ic13ajjZ66L3aXbNef8PELQ==",
+      "peerDependencies": {
+        "react-hook-form": "^7.0.0"
+      }
     },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.11.11",
@@ -7671,7 +7681,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
       "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "normalize-path": "^3.0.0",
         "picomatch": "^2.0.4"
@@ -8308,7 +8318,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
       "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=8"
       }
@@ -8819,7 +8829,7 @@
       "version": "3.5.3",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
       "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "individual",
@@ -8846,7 +8856,7 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "is-glob": "^4.0.1"
       },
@@ -12384,7 +12394,7 @@
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.4.tgz",
       "integrity": "sha512-fsXeu4J4i6WNWSikpI88v/PcVflZz+6kMhUfIwc5SY+poQRPnaf5V7qds6SUyUN3cVxEzuCab7QIoLOQ+DQ1wA==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/import-fresh": {
       "version": "3.3.0",
@@ -12546,7 +12556,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
       "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "binary-extensions": "^2.0.0"
       },
@@ -14414,6 +14424,14 @@
         }
       }
     },
+    "node_modules/next/node_modules/zod": {
+      "version": "3.21.4",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.21.4.tgz",
+      "integrity": "sha512-m46AKbrzKVzOzs/DZgVnG5H55N1sv1M8qZU3A8RIKbs3mrACDNeIOeilDymVb2HdmP8uwshOCF4uJ8uM9rCqJw==",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
     "node_modules/no-case": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
@@ -14556,7 +14574,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -16216,7 +16234,7 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
       "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "picomatch": "^2.2.1"
       },
@@ -16701,7 +16719,7 @@
       "version": "1.66.1",
       "resolved": "https://registry.npmjs.org/sass/-/sass-1.66.1.tgz",
       "integrity": "sha512-50c+zTsZOJVgFfTgwwEzkjA3/QACgdNsKueWPyAR0mRINIvLAStVQBbPg14iuqEQ74NPDbXzJARJ/O4SI1zftA==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "chokidar": ">=3.0.0 <4.0.0",
         "immutable": "^4.0.0",
@@ -19456,9 +19474,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.21.4",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.21.4.tgz",
-      "integrity": "sha512-m46AKbrzKVzOzs/DZgVnG5H55N1sv1M8qZU3A8RIKbs3mrACDNeIOeilDymVb2HdmP8uwshOCF4uJ8uM9rCqJw==",
+      "version": "3.22.2",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.22.2.tgz",
+      "integrity": "sha512-wvWkphh5WQsJbVk1tbx1l1Ly4yg+XecD+Mq280uBGt9wa5BKSWf4Mhp6GmrkPixhMxmabYY7RbzlwVP32pbGCg==",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/app/(root)/(routes)/user/edit/profile/page.tsx
+++ b/src/app/(root)/(routes)/user/edit/profile/page.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useEffect } from 'react'
+import Cookies from 'js-cookie'
 import { useRouter } from 'next/navigation'
 import ModalProvider from '@/components/molcules/ModalLayout'
 import PasswordInputModal from '@/components/organisms/PasswordInputModal'
@@ -13,40 +14,37 @@ export default function EditProfile() {
   const router = useRouter()
   const { isModalOpen, handleModalOpen, handleModalClose } = useModal()
   const { isAuthUser, setIsAuthUser } = useCheckPassword()
+  const isVerified = Cookies.get('verified-user')
 
   useEffect(() => {
     handleModalOpen()
   })
 
   useEffect(() => {
-    if (isAuthUser) {
+    if (isVerified) {
+      setIsAuthUser(true)
       handleModalClose()
     }
-  }, [handleModalClose, isAuthUser])
+  }, [handleModalClose, setIsAuthUser, isVerified])
 
   const handlePWModalClose = () => {
     handleModalClose()
     router.push(APP_PATH.home())
   }
 
-  return isModalOpen ? (
+  return !isAuthUser ? (
     <ModalProvider
       modalWidth={41}
       modalHeight={44}
-      isOpen={true}
+      isOpen={isModalOpen}
       handleModalClose={() => {
         handlePWModalClose()
       }}
       clickOutsideToClose={false}
     >
-      <PasswordInputModal
-        handleModalClose={handlePWModalClose}
-        setIsAuthUser={setIsAuthUser}
-      />
+      <PasswordInputModal setIsAuthUser={setIsAuthUser} />
     </ModalProvider>
-  ) : isAuthUser ? (
-    <EditProfileTemplate />
   ) : (
-    <></>
+    <EditProfileTemplate />
   )
 }

--- a/src/components/molcules/EditNamesForm/EditNamesform.tsx
+++ b/src/components/molcules/EditNamesForm/EditNamesform.tsx
@@ -1,10 +1,9 @@
+import { useState } from 'react'
 import { useForm } from 'react-hook-form'
 import { Button } from '@/components/atoms/Button'
 import Input from '@/components/atoms/Input'
 import { notify } from '@/components/atoms/Toast'
-import { useValidate } from '@/hooks/useCurrentUser'
 import { useEditProfile } from '@/hooks/useEditUserProfile'
-import useGetAllUsers from '@/queries/users'
 
 interface FormValues {
   fullName: string
@@ -16,9 +15,8 @@ export type NameProps = {
 }
 
 const EditNamesform = ({ fullName }: NameProps) => {
-  const validate = useValidate()
-  const getAllUsers = useGetAllUsers()
   const { editProfile } = useEditProfile()
+  const [currentName, setCurrentName] = useState<string | undefined>(fullName)
 
   const { register, handleSubmit, setValue } = useForm<FormValues>({
     defaultValues: {
@@ -32,10 +30,10 @@ const EditNamesform = ({ fullName }: NameProps) => {
       onSubmit={handleSubmit(async (data) => {
         try {
           await editProfile(data)
+          setCurrentName(data.fullName)
           notify('success', '닉네임이 수정되었습니다.')
-          validate.refetch()
-          getAllUsers.refetch()
           setValue('fullName', '')
+          location.reload()
         } catch (error) {
           notify('error', '닉네임 수정에 실패했습니다.')
         }
@@ -47,7 +45,7 @@ const EditNamesform = ({ fullName }: NameProps) => {
           register('fullName', {
             required: true,
           }))}
-        placeholder={fullName}
+        placeholder={currentName || fullName}
         variant="clear"
         outline="underbar"
         style={{

--- a/src/components/molcules/EditProfileImageForm/EditProfileImageForm.tsx
+++ b/src/components/molcules/EditProfileImageForm/EditProfileImageForm.tsx
@@ -1,13 +1,11 @@
-import { useRef, useState, ChangeEvent } from 'react'
+import { useRef, useState, ChangeEvent, useEffect } from 'react'
 import { FiSettings } from 'react-icons/fi'
 import Image from 'next/image'
 import { Button } from '@/components/atoms/Button'
 import { notify } from '@/components/atoms/Toast'
 import { SetEditProfileComponent } from '@/components/organisms/EditProfile/EditProfile'
 import Assets from '@/config/assets'
-import { useValidate } from '@/hooks/useCurrentUser'
 import { useEditProfileImage } from '@/hooks/useEditUserImage'
-import useGetAllUsers from '@/queries/users'
 import './index.scss'
 
 type EditProfileImageFormProps = SetEditProfileComponent & {
@@ -18,12 +16,14 @@ const EditProfileImageForm = ({
   setPage,
   image,
 }: EditProfileImageFormProps) => {
-  const validate = useValidate()
-  const getAllUsers = useGetAllUsers()
   const { editProfileImage } = useEditProfileImage()
   const [profile, setProfile] = useState<File | null>(null)
   const selectProfileFile = useRef<HTMLInputElement | null>(null)
-  const [thumnail, setThumnail] = useState(image || Assets.PCCImage)
+  const [thumnail, setThumnail] = useState(image)
+
+  useEffect(() => {
+    setThumnail(image)
+  }, [image])
 
   const handleFileChange = (e: ChangeEvent<HTMLInputElement>) => {
     e.preventDefault()
@@ -52,7 +52,7 @@ const EditProfileImageForm = ({
         onClick={() => selectProfileFile?.current?.click()}
       >
         <Image
-          src={thumnail}
+          src={thumnail ?? Assets.PCCImage}
           width={180}
           height={180}
           style={{ borderRadius: '50%' }}
@@ -74,9 +74,8 @@ const EditProfileImageForm = ({
                 isCover: false,
                 image: profile!,
               })
-              validate.refetch()
-              getAllUsers.refetch()
               setProfile(null)
+              location.reload()
             }
           }}
           isShadowed={true}

--- a/src/components/organisms/EditProfile/EditProfile.tsx
+++ b/src/components/organisms/EditProfile/EditProfile.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react'
+import { useMemo } from 'react'
 import { Text } from '@/components/atoms/Text'
 import EditNamesform from '@/components/molcules/EditNamesForm'
 import EditProfileImageForm from '@/components/molcules/EditProfileImageForm'
@@ -36,4 +36,4 @@ const EditProfile = ({ setPage }: SetEditProfileComponent) => {
   )
 }
 
-export default React.memo(EditProfile)
+export default EditProfile

--- a/src/components/organisms/Header/Header.tsx
+++ b/src/components/organisms/Header/Header.tsx
@@ -12,7 +12,7 @@ import { useDarkmodeCookie } from '@/hooks/useDarkmodeCookie'
 import User from '@/types/user'
 import './index.scss'
 
-const getCurrentUser = async (): Promise<User | null | undefined> => {
+export const getCurrentUser = async (): Promise<User | null | undefined> => {
   const cookieStore = cookies()
   const token = cookieStore.get(constants.AUTH_TOKEN)
 

--- a/src/components/organisms/PasswordInputModal/PasswordInputModal.tsx
+++ b/src/components/organisms/PasswordInputModal/PasswordInputModal.tsx
@@ -1,21 +1,21 @@
-import React from 'react'
+import React, { useState } from 'react'
 import { useForm } from 'react-hook-form'
 import { AiOutlineClose } from 'react-icons/ai'
+import Cookies from 'js-cookie'
+import Link from 'next/link'
 import { Button } from '@/components/atoms/Button'
 import Input from '@/components/atoms/Input'
 import { Text } from '@/components/atoms/Text'
+import APP_PATH from '@/config/paths'
 import { useCheckPassword } from '@/hooks/useCheckPassword'
 import { useAuth } from '@/lib/contexts/authProvider'
 
 type HandleModalCloseProps = {
-  handleModalClose: () => void
   setIsAuthUser: React.Dispatch<React.SetStateAction<boolean>>
 }
 
-const PasswordInputModal = ({
-  handleModalClose,
-  setIsAuthUser,
-}: HandleModalCloseProps) => {
+const PasswordInputModal = ({ setIsAuthUser }: HandleModalCloseProps) => {
+  const [isVerifiedUser, setIsVerifiedUser] = useState(false)
   const { register, handleSubmit } = useForm()
   const { currentUser } = useAuth()
   const { checkUser } = useCheckPassword()
@@ -28,19 +28,22 @@ const PasswordInputModal = ({
           password,
         })
         if (user) {
+          Cookies.set('verified-user', JSON.stringify(!isVerifiedUser), {
+            expires: 1 / 144,
+          })
+          setIsVerifiedUser(!isVerifiedUser)
           setIsAuthUser(true)
         }
       })}
       style={{ padding: '4rem 3.6rem' }}
     >
-      <AiOutlineClose
-        onClick={() => {
-          handleModalClose()
-        }}
-        size={30}
-        color="gray-5"
-        style={{ float: 'right', cursor: 'pointer' }}
-      />
+      <Link href={APP_PATH.home()}>
+        <AiOutlineClose
+          size={30}
+          color="gray-5"
+          style={{ float: 'right', cursor: 'pointer' }}
+        />
+      </Link>
       <Text
         textStyle="heading1-bold"
         color="gray-5"


### PR DESCRIPTION
## - 목적
관련 이슈: #262, #273 
-

<br>

## - 주요 변경 사항

- 비밀번호 검증 모달 닫기 버튼을 누르면 바로 홈으로 이동하게 수정했습니다.
- 계정 정보 수정을 하면 location.reload() 하도록 변경했습니다.
- 계정 정보 수정 페이지에서 reload를 할 시 비밀번호 검증 모달창이 다시 뜨는 현상이 있어 비밀번호 검증 여부를 쿠키에 저장하도록 추가하였습니다.

## 기타 사항 (선택)

- 비밀번호 검증 여부를 쿠키에 저장하는 방식은 악의적으로 쿠키를 임의로 생성할 가능성도 배제할 순 없어 다른 방법이 없을지 고민중이지만 우선 쿠키에 저장하도록 했습니다.

<br>

## - 스크린샷 (선택)
