### PR TITLE
:bug: 팔로우 모달 낙관적 업데이트

### DIFF
--- a/src/components/molcules/ModalLayout/index.scss
+++ b/src/components/molcules/ModalLayout/index.scss
@@ -1,6 +1,6 @@
 @import '@/styles/variables.scss';
 .modal-background {
-  position: absolute;
+  position: fixed;
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);

--- a/src/components/organisms/FollowList/FollowList.tsx
+++ b/src/components/organisms/FollowList/FollowList.tsx
@@ -19,14 +19,22 @@ export default function FollowList({
         {isFollowerList ? '팔로워' : '팔로잉'}
       </Text>
       <ul className="follow-list">
-        {users?.map(({ _id, user, follower }, index) => {
-          const targetUserId = isFollowerList ? follower : user
-          return (
-            <div key={_id + index}>
-              <FollowListItem targetUserId={targetUserId} />
-            </div>
-          )
-        })}
+        {users?.length === 0 ? (
+          <div className="follow-list__message">
+            <Text textStyle="heading2" color="gray-4">{`${
+              isFollowerList ? '팔로워가' : '팔로우하는 유저가'
+            } 없습니다.`}</Text>
+          </div>
+        ) : (
+          users?.map(({ _id, user, follower }, index) => {
+            const targetUserId = isFollowerList ? follower : user
+            return (
+              <div key={_id + index}>
+                <FollowListItem targetUserId={targetUserId} />
+              </div>
+            )
+          })
+        )}
       </ul>
     </div>
   )

--- a/src/components/organisms/FollowList/index.scss
+++ b/src/components/organisms/FollowList/index.scss
@@ -12,6 +12,12 @@
   overflow: auto;
   height: 30rem;
   padding-right: 1rem;
+  &__message {
+    height: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
   &__item {
     display: flex;
     align-items: center;

--- a/src/components/organisms/NavBar/UserList/UserList.tsx
+++ b/src/components/organisms/NavBar/UserList/UserList.tsx
@@ -6,7 +6,7 @@ import { Text } from '@/components/atoms/Text'
 import APP_PATH from '@/config/paths'
 import useFollow from '@/hooks/useFollow'
 import useGetAllUsers from '@/queries/users'
-import User from '@/types/user'
+import { UserSummary } from '@/types/user'
 
 export default function UserList() {
   const { data } = useGetAllUsers()
@@ -27,7 +27,7 @@ export default function UserList() {
   )
 }
 
-function UserListItem({ userData }: { userData: User<string> }) {
+function UserListItem({ userData }: { userData: UserSummary }) {
   const { followerCount } = useFollow(userData)
   const { image, _id, fullName } = userData
   return (

--- a/src/components/organisms/UserDetailCard/section/Follows.tsx
+++ b/src/components/organisms/UserDetailCard/section/Follows.tsx
@@ -17,6 +17,7 @@ export default function Follows({ userData }: { userData: User }) {
     followerCount,
     followingCount,
     followToggle,
+    updatedUserData,
   } = useFollow(userData)
 
   const { isModalOpen, handleModalOpen, handleModalClose } = useModal()
@@ -63,7 +64,7 @@ export default function Follows({ userData }: { userData: User }) {
           <Suspense fallback={<Loading size={5} />}>
             <LazyFollowList
               isFollowerList={isFollowerModal}
-              userData={userData}
+              userData={updatedUserData}
             />
           </Suspense>
         )}

--- a/src/components/organisms/UserDetailCard/section/Follows.tsx
+++ b/src/components/organisms/UserDetailCard/section/Follows.tsx
@@ -37,12 +37,12 @@ export default function Follows({ userData }: { userData: User }) {
         <InfoCount
           text="팔로워"
           count={followerCount.toString()}
-          onClick={() => followerCount && handleFollowModalOpen(true)}
+          onClick={() => handleFollowModalOpen(true)}
         />
         <InfoCount
           text="팔로잉"
           count={followingCount.toString()}
-          onClick={() => followingCount && handleFollowModalOpen(false)}
+          onClick={() => handleFollowModalOpen(false)}
         />
       </div>
       <div className="follow_buttons">
@@ -83,11 +83,7 @@ const InfoCount = ({
 }) => {
   return (
     <>
-      <button
-        className="info_count"
-        onClick={onClick}
-        style={{ cursor: `${Number(count) === 0 ? 'auto' : 'pointer'}` }}
-      >
+      <button className="info_count" onClick={onClick}>
         <Text textStyle="body1-bold">{text}</Text>
         <Text textStyle="body1-bold">{count}</Text>
       </button>

--- a/src/hooks/useFollow.ts
+++ b/src/hooks/useFollow.ts
@@ -4,7 +4,7 @@ import { useEffect, useState } from 'react'
 import { useAuth } from '@/lib/contexts/authProvider'
 import { deleteFollow, postFollow } from '@/services/follow'
 import Follow from '@/types/follow'
-import User from '@/types/user'
+import User, { UserSummary } from '@/types/user'
 
 /**
  *
@@ -15,7 +15,8 @@ import User from '@/types/user'
  * @returns param followerCount: 현재 페이지의 유저의 팔로워 수
  * @returns param followingCount: 현재 페이지의 유저의 팔로잉 수
  */
-const useFollow = (userData: User<Follow | string> | undefined) => {
+
+const useFollow = (userData: User | UserSummary | undefined) => {
   const { currentUser } = useAuth()
 
   const [isFollowing, setIsFollowing] = useState(false)
@@ -23,6 +24,10 @@ const useFollow = (userData: User<Follow | string> | undefined) => {
   const [followId, setFollowId] = useState('')
   const [followerCount, setFollowerCount] = useState(0)
   const [followingCount, setFollowingCount] = useState(0)
+  const [updatedUserData, setUpdatedUserData] = useState(() => {
+    if (!userData) return undefined
+    return { ...userData }
+  })
 
   useEffect(() => {
     if (!userData) return
@@ -44,11 +49,21 @@ const useFollow = (userData: User<Follow | string> | undefined) => {
   }, [currentUser, userData])
 
   const followToggle = async () => {
-    if (!userData) return
+    if (!userData || !updatedUserData) return
     if (isFollowing) {
       setFollowerCount((prev) => prev - 1)
       setIsFollowing(false)
+
       if (!currentUser) return
+      setUpdatedUserData((prevUserData) => {
+        const user = prevUserData as User
+        return {
+          ...user,
+          followers: user.followers?.filter(
+            ({ follower }) => follower !== currentUser._id,
+          ),
+        }
+      })
       const followData = currentUser.following?.find(
         ({ user }) => user === userData._id,
       )
@@ -61,8 +76,16 @@ const useFollow = (userData: User<Follow | string> | undefined) => {
     } else {
       setIsFollowing(true)
       setFollowerCount((prev) => prev + 1)
+
       if (!currentUser) return
       const followData = await postFollow(userData._id)
+      setUpdatedUserData((prevUserData) => {
+        const user = prevUserData as User
+        return {
+          ...user,
+          followers: [...user.followers!, followData],
+        }
+      })
       setFollowId(() => followData._id ?? '')
       currentUser.following?.push(followData)
     }
@@ -75,6 +98,7 @@ const useFollow = (userData: User<Follow | string> | undefined) => {
     followingCount,
     unavailable: !currentUser || currentUser._id === userData?._id,
     followToggle,
+    updatedUserData: updatedUserData as User,
   }
 }
 

--- a/src/hooks/useFollow.ts
+++ b/src/hooks/useFollow.ts
@@ -25,9 +25,10 @@ const useFollow = (userData: User<Follow | string> | undefined) => {
   const [followingCount, setFollowingCount] = useState(0)
 
   useEffect(() => {
-    if (!userData || !currentUser) return
+    if (!userData) return
     setFollowerCount(() => userData.followers?.length ?? 0)
     setFollowingCount(() => userData.following?.length ?? 0)
+    if (!currentUser) return
     setIsFollowing(
       () =>
         currentUser.following?.some(
@@ -43,10 +44,11 @@ const useFollow = (userData: User<Follow | string> | undefined) => {
   }, [currentUser, userData])
 
   const followToggle = async () => {
-    if (!userData || !currentUser) return
+    if (!userData) return
     if (isFollowing) {
       setFollowerCount((prev) => prev - 1)
       setIsFollowing(false)
+      if (!currentUser) return
       const followData = currentUser.following?.find(
         ({ user }) => user === userData._id,
       )
@@ -59,6 +61,7 @@ const useFollow = (userData: User<Follow | string> | undefined) => {
     } else {
       setIsFollowing(true)
       setFollowerCount((prev) => prev + 1)
+      if (!currentUser) return
       const followData = await postFollow(userData._id)
       setFollowId(() => followData._id ?? '')
       currentUser.following?.push(followData)

--- a/src/hooks/useModal.ts
+++ b/src/hooks/useModal.ts
@@ -1,7 +1,15 @@
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 
 export default function useModal() {
   const [isModalOpen, setIsModalOpen] = useState<boolean>(false)
+
+  useEffect(() => {
+    if (isModalOpen) {
+      document.body.style.overflow = 'hidden'
+    } else {
+      document.body.style.overflow = 'visible'
+    }
+  }, [isModalOpen])
 
   const handleModalOpen = () => {
     setIsModalOpen(true)

--- a/src/queries/users/index.ts
+++ b/src/queries/users/index.ts
@@ -1,12 +1,12 @@
 import { useQuery } from '@tanstack/react-query'
 import { getAllUsers } from '@/services/user'
-import type User from '@/types/user'
+import { UserSummary } from '@/types/user'
 
 const useGetAllUsers = () => {
   return useQuery({
     queryKey: ['getAllUsers'],
     queryFn: async () => {
-      const data: User<string>[] = await getAllUsers()
+      const data: UserSummary[] = await getAllUsers()
       return data
     },
   })

--- a/src/types/user/index.ts
+++ b/src/types/user/index.ts
@@ -4,7 +4,7 @@ import Message from '../message'
 import Notification from '../notification'
 import Post from '../post'
 
-interface User<T = Follow> {
+interface User {
   name: string
   email: string
   coverImage?: string
@@ -14,8 +14,8 @@ interface User<T = Follow> {
   posts?: Post[]
   likes?: Like[]
   comments?: string[]
-  followers?: T[]
-  following?: T[]
+  followers?: Follow[]
+  following?: Follow[]
   notifications?: Notification[]
   messages?: Message[]
   _id: string
@@ -27,6 +27,7 @@ interface User<T = Follow> {
 export interface UserSummary {
   role: string
   emailVerified?: boolean
+  image?: string
   banned?: boolean
   isOnline?: boolean
   posts?: Post[]
@@ -42,22 +43,6 @@ export interface UserSummary {
   createdAt?: string
   updatedAt?: string
   __v?: number
-}
-
-interface Following {
-  _id: string
-  user: string
-  follower: string
-  createdAt: string
-  updatedAt: string
-}
-
-interface Follower {
-  _id: string
-  user: string
-  follower: string
-  createdAt: string
-  updatedAt: string
 }
 
 export default User


### PR DESCRIPTION
## - 목적
관련 이슈: #272 #243 
-

<br>

## - 주요 변경 사항

- 유저 디테일 카드에서 팔로우 / 팔로우 취소 시 모달에도 낙관적 업데이트
- updatedUserData 복사본을 만들어 모달의 FollowList에 전달

## 기타 사항 (선택)

- User 제네릭 타입을 제거하고 User 또는 UserSummary를 사용하도록 수정

<br>

## - 스크린샷 (선택)
