### PR TITLE
:bug: 모달에서 팔로우/팔로우 취소 동작 안되는 문제 해결

### DIFF
--- a/src/hooks/useFollow.ts
+++ b/src/hooks/useFollow.ts
@@ -45,6 +45,7 @@ const useFollow = (userData: User | UserSummary | undefined) => {
           (follower) => userData._id === follower._id,
         ) ?? false,
     )
+    setUpdatedUserData(() => ({ ...userData }))
   }, [currentUser, userData])
 
   const followToggle = async () => {


### PR DESCRIPTION
## - 목적
관련 이슈: #312 
-

<br>

## - 주요 변경 사항

### 문제 원인
- 유저 프로필에서 팔로우를 했을 때 팔로워 모달을 열면 바로 내가 바로 반영되도록 updatedUser 상태를 새로 만들었었음
- 데이터를 다 불러와서 userData가 undefined가 아니게 되면 updatedUser도 같이 업데이트를 해줬어야 함
- 그걸 안하면 updatedUser도 계속 undefined라 undefined 방어 코드 (조건문)에서 리턴돼서 팔로우가 제대로 동작을 못하고 있었음

<br>  
- userData가 불러와지면 updatedUserData도 같이 업데이트하도록 수정했습니다 !!!

## 기타 사항 (선택)

-

<br>

## - 스크린샷 (선택)
